### PR TITLE
Remove internal access modifier to make errors Map accessible from outside

### DIFF
--- a/common/src/main/kotlin/io/konform/validation/ValidationResult.kt
+++ b/common/src/main/kotlin/io/konform/validation/ValidationResult.kt
@@ -8,7 +8,7 @@ sealed class ValidationResult<T> {
 }
 
 data class Invalid<T>(
-    internal val errors: Map<List<String>, List<String>>) : ValidationResult<T>() {
+    val errors: Map<List<String>, List<String>>) : ValidationResult<T>() {
 
     override fun get(vararg propertyPath: Any): List<String>? =
         errors[propertyPath.map(::toPathSegment)]


### PR DESCRIPTION
Hey!
This fixes #3.
As there was no real result from the issue comments and I think everyone would be fine to at least have access to the `errors`, the easiest way would be to just expose the `errors` map to everyone.

Thanks,
Kenneth