### PR TITLE
Added missing '-jvm' to artifactId

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For jvm-only projects add:
 
 ```
 dependencies {
-    implementation("io.konform:konform:0.3.0")
+    implementation("io.konform:konform-jvm:0.3.0")
 }
 ```
 


### PR DESCRIPTION
Adding the dependency `io.konform:konform:0.3.0` to a JVM project does not produce and error, but the implementation is not pulled in so it does not work.  It took me quite a while to spot the tiny documentation error.