### PR TITLE
Add DSLMarker to scope the methods on ValidationBuilder

### DIFF
--- a/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
@@ -3,6 +3,10 @@ package io.konform.validation
 import kotlin.jvm.JvmName
 import kotlin.reflect.KProperty1
 
+@DslMarker
+private annotation class ValidationScope
+
+@ValidationScope
 abstract class ValidationBuilder<T> {
     abstract fun build(): Validation<T>
     abstract fun addConstraint(errorMessage: String, vararg templateValues: String, test: (T) -> Boolean): Constraint<T>


### PR DESCRIPTION
Otherwise we end up accidentally adding Validations to an outer `ValidationBuilder` from somewhere inside a nested `ValidationBuilder`