### PR TITLE
get rid of compileOnly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                compileOnly kotlin('stdlib')
+                api kotlin('stdlib')
             }
         }
         commonTest {
@@ -59,9 +59,6 @@ kotlin {
             }
         }
         jvmMain {
-            dependencies {
-                compileOnly kotlin('stdlib-jdk8')
-            }
         }
         jvmTest {}
         jsMain {}


### PR DESCRIPTION
causing issues with our build

use api instead. I think compileOnly is sort of deprecated in any case.
