### PR TITLE
Native platforms support

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,7 +12,9 @@ permissions:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+#    runs-on: ubuntu-latest
+#      In order to build macOS/iOS platforms
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,33 @@ kotlin {
         browser()
         nodejs()
     }
+
+    linuxX64()
+//    linuxArm64()
+//    linuxArm32Hfp()
+//    linuxMips32()
+//    linuxMipsel32()
+    ios()
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+    macosX64()
+    macosArm64()
+    tvos()
+    tvosArm64()
+    tvosSimulatorArm64()
+    tvosX64()
+    watchos()
+    watchosArm32()
+    watchosSimulatorArm64()
+    watchosArm64()
+    watchosX86()
+    watchosX64()
+//    wasm()
+//    wasm32()
+//    mingwX86()
+    mingwX64()
+
     sourceSets {
         commonMain {
             dependencies {


### PR DESCRIPTION
Please accept this pull request. It includes the following changes
1. Native platforms are added to build.gradle
2. Runner environment is changed to macos to provide Apple's native platforms builds

According to my checks all tests are passed successfully.