### PR TITLE
Make validations context aware

### DIFF
--- a/src/commonMain/kotlin/io/konform/validation/Validation.kt
+++ b/src/commonMain/kotlin/io/konform/validation/Validation.kt
@@ -1,19 +1,27 @@
 package io.konform.validation
 
 import io.konform.validation.internal.ValidationBuilderImpl
+import kotlin.jvm.JvmName
 
-interface Validation<T> {
+interface Validation<C, T> {
 
     companion object {
-        operator fun <T> invoke(init: ValidationBuilder<T>.() -> Unit): Validation<T> {
-            val builder = ValidationBuilderImpl<T>()
+        operator fun <C, T> invoke(init: ValidationBuilder<C, T>.() -> Unit): Validation<C, T> {
+            val builder = ValidationBuilderImpl<C, T>()
+            return builder.apply(init).build()
+        }
+
+        @JvmName("simpleInvoke")
+        operator fun <T> invoke(init: ValidationBuilder<Unit, T>.() -> Unit): Validation<Unit, T> {
+            val builder = ValidationBuilderImpl<Unit, T>()
             return builder.apply(init).build()
         }
     }
 
-    fun validate(value: T): ValidationResult<T>
-    operator fun invoke(value: T) = validate(value)
+    fun validate(context: C, value: T): ValidationResult<T>
+    operator fun invoke(context: C, value: T) = validate(context, value)
 }
 
+operator fun <T> Validation<Unit, T>.invoke(value: T) = validate(Unit, value)
 
-class Constraint<R> internal constructor(val hint: String, val templateValues: List<String>, val test: (R) -> Boolean)
+class Constraint<C, R> internal constructor(val hint: String, val templateValues: List<String>, val test: (C, R) -> Boolean)

--- a/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
@@ -16,8 +16,6 @@ private annotation class ValidationScope
 abstract class ValidationBuilder<C, T> {
     abstract fun build(): Validation<C, T>
     abstract fun addConstraint(errorMessage: String, vararg templateValues: String, test: C.(T) -> Boolean): Constraint<C, T>
-//    fun addConstraint(errorMessage: String, vararg templateValues: String, test: (T) -> Boolean): Constraint<C, T> =
-//        addConstraint(errorMessage, *templateValues) { _, value -> test(value) }
     abstract infix fun Constraint<C, T>.hint(hint: String): Constraint<C, T>
     abstract operator fun <R> KProperty1<T, R>.invoke(init: ValidationBuilder<C, R>.() -> Unit)
     internal abstract fun <R> onEachIterable(prop: KProperty1<T, Iterable<R>>, init: ValidationBuilder<C, R>.() -> Unit)

--- a/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
@@ -32,6 +32,7 @@ abstract class ValidationBuilder<C, T> {
     abstract infix fun <R> KProperty1<T, R?>.ifPresent(init: ValidationBuilder<C, R>.() -> Unit)
     abstract infix fun <R> KProperty1<T, R?>.required(init: ValidationBuilder<C, R>.() -> Unit)
     abstract fun run(validation: Validation<C, T>)
+    abstract fun <S> run(validation: Validation<S, T>, map: (C) -> S)
     abstract val <R> KProperty1<T, R>.has: ValidationBuilder<C, R>
 }
 

--- a/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
@@ -15,9 +15,9 @@ private annotation class ValidationScope
 @ValidationScope
 abstract class ValidationBuilder<C, T> {
     abstract fun build(): Validation<C, T>
-    abstract fun addConstraint(errorMessage: String, vararg templateValues: String, test: (C, T) -> Boolean): Constraint<C, T>
-    fun addSimpleConstraint(errorMessage: String, vararg templateValues: String, test: (T) -> Boolean): Constraint<C, T> =
-        addConstraint(errorMessage, *templateValues) { _, value -> test(value) }
+    abstract fun addConstraint(errorMessage: String, vararg templateValues: String, test: C.(T) -> Boolean): Constraint<C, T>
+//    fun addConstraint(errorMessage: String, vararg templateValues: String, test: (T) -> Boolean): Constraint<C, T> =
+//        addConstraint(errorMessage, *templateValues) { _, value -> test(value) }
     abstract infix fun Constraint<C, T>.hint(hint: String): Constraint<C, T>
     abstract operator fun <R> KProperty1<T, R>.invoke(init: ValidationBuilder<C, R>.() -> Unit)
     internal abstract fun <R> onEachIterable(prop: KProperty1<T, Iterable<R>>, init: ValidationBuilder<C, R>.() -> Unit)

--- a/src/commonMain/kotlin/io/konform/validation/internal/Builder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/internal/Builder.kt
@@ -141,6 +141,10 @@ internal class ValidationBuilderImpl<C, T> : ValidationBuilder<C, T>() {
         prebuiltValidations.add(validation)
     }
 
+    override fun <S> run(validation: Validation<S, T>, map: (C) -> S) {
+        prebuiltValidations.add(MappedValidation(validation, map))
+    }
+
     override fun build(): Validation<C, T> {
         val nestedValidations = subValidations.map { (key, builder) ->
             key.build(builder)

--- a/src/commonMain/kotlin/io/konform/validation/internal/Builder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/internal/Builder.kt
@@ -9,23 +9,23 @@ import io.konform.validation.internal.ValidationBuilderImpl.Companion.PropModifi
 import kotlin.collections.Map.Entry
 import kotlin.reflect.KProperty1
 
-internal class ValidationBuilderImpl<T> : ValidationBuilder<T>() {
+internal class ValidationBuilderImpl<C, T> : ValidationBuilder<C, T>() {
     companion object {
         private enum class PropModifier {
             NonNull, Optional, OptionalRequired
         }
 
-        private abstract class PropKey<T> {
-            abstract fun build(builder: ValidationBuilderImpl<*>): Validation<T>
+        private abstract class PropKey<C, T> {
+            abstract fun build(builder: ValidationBuilderImpl<C, *>): Validation<C, T>
         }
 
-        private data class SingleValuePropKey<T, R>(
+        private data class SingleValuePropKey<C, T, R>(
             val property: KProperty1<T, R>,
             val modifier: PropModifier
-        ) : PropKey<T>() {
-            override fun build(builder: ValidationBuilderImpl<*>): Validation<T> {
+        ) : PropKey<C, T>() {
+            override fun build(builder: ValidationBuilderImpl<C, *>): Validation<C, T> {
                 @Suppress("UNCHECKED_CAST")
-                val validations = (builder as ValidationBuilderImpl<R>).build()
+                val validations = (builder as ValidationBuilderImpl<C, R>).build()
                 return when (modifier) {
                     NonNull -> NonNullPropertyValidation(property, validations)
                     Optional -> OptionalPropertyValidation(property, validations)
@@ -34,13 +34,13 @@ internal class ValidationBuilderImpl<T> : ValidationBuilder<T>() {
             }
         }
 
-        private data class IterablePropKey<T, R>(
+        private data class IterablePropKey<C, T, R>(
             val property: KProperty1<T, Iterable<R>>,
             val modifier: PropModifier
-        ) : PropKey<T>() {
-            override fun build(builder: ValidationBuilderImpl<*>): Validation<T> {
+        ) : PropKey<C, T>() {
+            override fun build(builder: ValidationBuilderImpl<C, *>): Validation<C, T> {
                 @Suppress("UNCHECKED_CAST")
-                val validations = (builder as ValidationBuilderImpl<R>).build()
+                val validations = (builder as ValidationBuilderImpl<C, R>).build()
                 @Suppress("UNCHECKED_CAST")
                 return when (modifier) {
                     NonNull -> NonNullPropertyValidation(property, IterableValidation(validations))
@@ -50,13 +50,13 @@ internal class ValidationBuilderImpl<T> : ValidationBuilder<T>() {
             }
         }
 
-        private data class ArrayPropKey<T, R>(
+        private data class ArrayPropKey<C, T, R>(
             val property: KProperty1<T, Array<R>>,
             val modifier: PropModifier
-        ) : PropKey<T>() {
-            override fun build(builder: ValidationBuilderImpl<*>): Validation<T> {
+        ) : PropKey<C, T>() {
+            override fun build(builder: ValidationBuilderImpl<C, *>): Validation<C, T> {
                 @Suppress("UNCHECKED_CAST")
-                val validations = (builder as ValidationBuilderImpl<R>).build()
+                val validations = (builder as ValidationBuilderImpl<C, R>).build()
                 @Suppress("UNCHECKED_CAST")
                 return when (modifier) {
                     NonNull -> NonNullPropertyValidation(property, ArrayValidation(validations))
@@ -66,13 +66,13 @@ internal class ValidationBuilderImpl<T> : ValidationBuilder<T>() {
             }
         }
 
-        private data class MapPropKey<T, K, V>(
+        private data class MapPropKey<C, T, K, V>(
             val property: KProperty1<T, Map<K, V>>,
             val modifier: PropModifier
-        ) : PropKey<T>() {
-            override fun build(builder: ValidationBuilderImpl<*>): Validation<T> {
+        ) : PropKey<C, T>() {
+            override fun build(builder: ValidationBuilderImpl<C, *>): Validation<C, T> {
                 @Suppress("UNCHECKED_CAST")
-                val validations = (builder as ValidationBuilderImpl<Map.Entry<K, V>>).build()
+                val validations = (builder as ValidationBuilderImpl<C, Entry<K, V>>).build()
                 return when (modifier) {
                     NonNull -> NonNullPropertyValidation(property, MapValidation(validations))
                     Optional -> OptionalPropertyValidation(property, MapValidation(validations))
@@ -84,66 +84,66 @@ internal class ValidationBuilderImpl<T> : ValidationBuilder<T>() {
 
     }
 
-    private val constraints = mutableListOf<Constraint<T>>()
-    private val subValidations = mutableMapOf<PropKey<T>, ValidationBuilderImpl<*>>()
-    private val prebuiltValidations = mutableListOf<Validation<T>>()
+    private val constraints = mutableListOf<Constraint<C, T>>()
+    private val subValidations = mutableMapOf<PropKey<C, T>, ValidationBuilderImpl<C, *>>()
+    private val prebuiltValidations = mutableListOf<Validation<C, T>>()
 
-    override fun Constraint<T>.hint(hint: String): Constraint<T> =
+    override fun Constraint<C, T>.hint(hint: String): Constraint<C, T> =
         Constraint(hint, this.templateValues, this.test).also { constraints.remove(this); constraints.add(it) }
 
-    override fun addConstraint(errorMessage: String, vararg templateValues: String, test: (T) -> Boolean): Constraint<T> {
+    override fun addConstraint(errorMessage: String, vararg templateValues: String, test: (C, T) -> Boolean): Constraint<C, T> {
         return Constraint(errorMessage, templateValues.toList(), test).also { constraints.add(it) }
     }
 
-    private fun <R> KProperty1<T, R?>.getOrCreateBuilder(modifier: PropModifier): ValidationBuilder<R> {
-        val key = SingleValuePropKey(this, modifier)
+    private fun <R> KProperty1<T, R?>.getOrCreateBuilder(modifier: PropModifier): ValidationBuilder<C, R> {
+        val key = SingleValuePropKey<C, T, R?>(this, modifier)
         @Suppress("UNCHECKED_CAST")
-        return (subValidations.getOrPut(key, { ValidationBuilderImpl<R>() }) as ValidationBuilder<R>)
+        return (subValidations.getOrPut(key, { ValidationBuilderImpl<C, R>() }) as ValidationBuilder<C, R>)
     }
 
-    private fun <R> KProperty1<T, Iterable<R>>.getOrCreateIterablePropertyBuilder(modifier: PropModifier): ValidationBuilder<R> {
-        val key = IterablePropKey(this, modifier)
+    private fun <R> KProperty1<T, Iterable<R>>.getOrCreateIterablePropertyBuilder(modifier: PropModifier): ValidationBuilder<C, R> {
+        val key = IterablePropKey<C, T, R>(this, modifier)
         @Suppress("UNCHECKED_CAST")
-        return (subValidations.getOrPut(key, { ValidationBuilderImpl<R>() }) as ValidationBuilder<R>)
+        return (subValidations.getOrPut(key, { ValidationBuilderImpl<C, R>() }) as ValidationBuilder<C, R>)
     }
 
-    private fun <R> PropKey<T>.getOrCreateBuilder(): ValidationBuilder<R> {
+    private fun <R> PropKey<C, T>.getOrCreateBuilder(): ValidationBuilder<C, R> {
         @Suppress("UNCHECKED_CAST")
-        return (subValidations.getOrPut(this, { ValidationBuilderImpl<R>() }) as ValidationBuilder<R>)
+        return (subValidations.getOrPut(this, { ValidationBuilderImpl<C, R>() }) as ValidationBuilder<C, R>)
     }
 
-    override fun <R> KProperty1<T, R>.invoke(init: ValidationBuilder<R>.() -> Unit) {
+    override fun <R> KProperty1<T, R>.invoke(init: ValidationBuilder<C, R>.() -> Unit) {
         getOrCreateBuilder(NonNull).also(init)
     }
 
-    override fun <R> onEachIterable(prop: KProperty1<T, Iterable<R>>, init: ValidationBuilder<R>.() -> Unit) {
+    override fun <R> onEachIterable(prop: KProperty1<T, Iterable<R>>, init: ValidationBuilder<C, R>.() -> Unit) {
         prop.getOrCreateIterablePropertyBuilder(NonNull).also(init)
     }
 
-    override fun <R> onEachArray(prop: KProperty1<T, Array<R>>, init: ValidationBuilder<R>.() -> Unit) {
-        ArrayPropKey(prop, NonNull).getOrCreateBuilder<R>().also(init)
+    override fun <R> onEachArray(prop: KProperty1<T, Array<R>>, init: ValidationBuilder<C, R>.() -> Unit) {
+        ArrayPropKey<C, T, R>(prop, NonNull).getOrCreateBuilder<R>().also(init)
     }
 
-    override fun <K, V> onEachMap(prop: KProperty1<T, Map<K, V>>, init: ValidationBuilder<Entry<K, V>>.() -> Unit) {
-        MapPropKey(prop, NonNull).getOrCreateBuilder<Map.Entry<K, V>>().also(init)
+    override fun <K, V> onEachMap(prop: KProperty1<T, Map<K, V>>, init: ValidationBuilder<C, Entry<K, V>>.() -> Unit) {
+        MapPropKey<C, T, K, V>(prop, NonNull).getOrCreateBuilder<Entry<K, V>>().also(init)
     }
 
-    override fun <R> KProperty1<T, R?>.ifPresent(init: ValidationBuilder<R>.() -> Unit) {
+    override fun <R> KProperty1<T, R?>.ifPresent(init: ValidationBuilder<C, R>.() -> Unit) {
         getOrCreateBuilder(Optional).also(init)
     }
 
-    override fun <R> KProperty1<T, R?>.required(init: ValidationBuilder<R>.() -> Unit) {
+    override fun <R> KProperty1<T, R?>.required(init: ValidationBuilder<C, R>.() -> Unit) {
         getOrCreateBuilder(OptionalRequired).also(init)
     }
 
-    override val <R> KProperty1<T, R>.has: ValidationBuilder<R>
+    override val <R> KProperty1<T, R>.has: ValidationBuilder<C, R>
         get() = getOrCreateBuilder(NonNull)
 
-    override fun run(validation: Validation<T>) {
+    override fun run(validation: Validation<C, T>) {
         prebuiltValidations.add(validation)
     }
 
-    override fun build(): Validation<T> {
+    override fun build(): Validation<C, T> {
         val nestedValidations = subValidations.map { (key, builder) ->
             key.build(builder)
         }

--- a/src/commonMain/kotlin/io/konform/validation/internal/Builder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/internal/Builder.kt
@@ -80,8 +80,6 @@ internal class ValidationBuilderImpl<C, T> : ValidationBuilder<C, T>() {
                 }
             }
         }
-
-
     }
 
     private val constraints = mutableListOf<Constraint<C, T>>()

--- a/src/commonMain/kotlin/io/konform/validation/internal/Validation.kt
+++ b/src/commonMain/kotlin/io/konform/validation/internal/Validation.kt
@@ -7,6 +7,14 @@ import io.konform.validation.Validation
 import io.konform.validation.ValidationResult
 import kotlin.reflect.KProperty1
 
+internal class MappedValidation<C, S, T>(
+    private val validation: Validation<S, T>,
+    private val map: (C) -> S,
+) : Validation<C, T> {
+    override fun validate(context: C, value: T): ValidationResult<T> =
+        validation(map(context), value)
+}
+
 internal class OptionalValidation<C, T: Any>(
     private val validation: Validation<C, T>
 ) : Validation<C, T?> {

--- a/src/commonMain/kotlin/io/konform/validation/internal/Validation.kt
+++ b/src/commonMain/kotlin/io/konform/validation/internal/Validation.kt
@@ -7,105 +7,102 @@ import io.konform.validation.Validation
 import io.konform.validation.ValidationResult
 import kotlin.reflect.KProperty1
 
-internal class OptionalValidation<T: Any>(
-    private val validation: Validation<T>
-) : Validation<T?> {
-    override fun validate(value: T?): ValidationResult<T?> {
+internal class OptionalValidation<C, T: Any>(
+    private val validation: Validation<C, T>
+) : Validation<C, T?> {
+    override fun validate(context: C, value: T?): ValidationResult<T?> {
         val nonNullValue = value ?: return Valid(value)
-        return validation(nonNullValue)
+        return validation(context, nonNullValue)
     }
 }
 
-internal class RequiredValidation<T: Any>(
-    private val validation: Validation<T>
-) : Validation<T?> {
-    override fun validate(value: T?): ValidationResult<T?> {
+internal class RequiredValidation<C, T: Any>(
+    private val validation: Validation<C, T>
+) : Validation<C, T?> {
+    override fun validate(context: C, value: T?): ValidationResult<T?> {
         val nonNullValue = value
             ?: return Invalid(mapOf("" to listOf("is required")))
-        return validation(nonNullValue)
+        return validation(context, nonNullValue)
     }
 }
 
-internal class NonNullPropertyValidation<T, R>(
+internal class NonNullPropertyValidation<C, T, R>(
     private val property: KProperty1<T, R>,
-    private val validation: Validation<R>
-) : Validation<T> {
-    override fun validate(value: T): ValidationResult<T> {
+    private val validation: Validation<C, R>
+) : Validation<C, T> {
+    override fun validate(context: C, value: T): ValidationResult<T> {
         val propertyValue = property(value)
-        return validation(propertyValue).mapError { ".${property.name}$it" }.map { value }
+        return validation(context, propertyValue).mapError { ".${property.name}$it" }.map { value }
     }
 }
 
-internal class OptionalPropertyValidation<T, R>(
+internal class OptionalPropertyValidation<C, T, R>(
     private val property: KProperty1<T, R?>,
-    private val validation: Validation<R>
-) : Validation<T> {
-    override fun validate(value: T): ValidationResult<T> {
+    private val validation: Validation<C, R>
+) : Validation<C, T> {
+    override fun validate(context: C, value: T): ValidationResult<T> {
         val propertyValue = property(value) ?: return Valid(value)
-        return validation(propertyValue).mapError { ".${property.name}$it" }.map { value }
+        return validation(context, propertyValue).mapError { ".${property.name}$it" }.map { value }
     }
 }
 
-internal class RequiredPropertyValidation<T, R>(
+internal class RequiredPropertyValidation<C, T, R>(
     private val property: KProperty1<T, R?>,
-    private val validation: Validation<R>
-) : Validation<T> {
-    override fun validate(value: T): ValidationResult<T> {
+    private val validation: Validation<C, R>
+) : Validation<C, T> {
+    override fun validate(context: C, value: T): ValidationResult<T> {
         val propertyValue = property(value)
             ?: return Invalid<T>(mapOf(".${property.name}" to listOf("is required")))
-        return validation(propertyValue).mapError { ".${property.name}${it}" }.map { value }
+        return validation(context, propertyValue).mapError { ".${property.name}${it}" }.map { value }
     }
 }
 
-internal class IterableValidation<T>(
-    private val validation: Validation<T>
-) : Validation<Iterable<T>> {
-    override fun validate(value: Iterable<T>): ValidationResult<Iterable<T>> {
+internal class IterableValidation<C, T>(
+    private val validation: Validation<C, T>
+) : Validation<C, Iterable<T>> {
+    override fun validate(context: C, value: Iterable<T>): ValidationResult<Iterable<T>> {
         return value.foldIndexed(Valid(value)) { index, result: ValidationResult<Iterable<T>>, propertyValue ->
-            val propertyValidation = validation(propertyValue).mapError { "[$index]$it" }.map { value }
+            val propertyValidation = validation(context, propertyValue).mapError { "[$index]$it" }.map { value }
             result.combineWith(propertyValidation)
         }
-
     }
 }
 
-internal class ArrayValidation<T>(
-    private val validation: Validation<T>
-) : Validation<Array<T>> {
-    override fun validate(value: Array<T>): ValidationResult<Array<T>> {
+internal class ArrayValidation<C, T>(
+    private val validation: Validation<C, T>
+) : Validation<C, Array<T>> {
+    override fun validate(context: C, value: Array<T>): ValidationResult<Array<T>> {
         return value.foldIndexed(Valid(value)) { index, result: ValidationResult<Array<T>>, propertyValue ->
-            val propertyValidation = validation(propertyValue).mapError { "[$index]$it" }.map { value }
+            val propertyValidation = validation(context, propertyValue).mapError { "[$index]$it" }.map { value }
             result.combineWith(propertyValidation)
         }
-
     }
 }
 
-internal class MapValidation<K, V>(
-    private val validation: Validation<Map.Entry<K, V>>
-) : Validation<Map<K, V>> {
-    override fun validate(value: Map<K, V>): ValidationResult<Map<K, V>> {
+internal class MapValidation<C, K, V>(
+    private val validation: Validation<C, Map.Entry<K, V>>
+) : Validation<C, Map<K, V>> {
+    override fun validate(context: C, value: Map<K, V>): ValidationResult<Map<K, V>> {
         return value.asSequence().fold(Valid(value)) { result: ValidationResult<Map<K, V>>, entry ->
-            val propertyValidation = validation(entry).mapError { ".${entry.key.toString()}${it.removePrefix(".value")}" }.map { value }
+            val propertyValidation = validation(context, entry).mapError { ".${entry.key.toString()}${it.removePrefix(".value")}" }.map { value }
             result.combineWith(propertyValidation)
         }
-
     }
 }
 
-internal class ValidationNode<T>(
-    private val constraints: List<Constraint<T>>,
-    private val subValidations: List<Validation<T>>
-) : Validation<T> {
-    override fun validate(value: T): ValidationResult<T> {
-        val subValidationResult = applySubValidations(value, keyTransform = { it })
-        val localValidationResult = localValidation(value)
+internal class ValidationNode<C, T>(
+    private val constraints: List<Constraint<C, T>>,
+    private val subValidations: List<Validation<C, T>>
+) : Validation<C, T> {
+    override fun validate(context: C, value: T): ValidationResult<T> {
+        val subValidationResult = applySubValidations(context, value, keyTransform = { it })
+        val localValidationResult = localValidation(context, value)
         return localValidationResult.combineWith(subValidationResult)
     }
 
-    private fun localValidation(value: T): ValidationResult<T> {
+    private fun localValidation(context: C, value: T): ValidationResult<T> {
         return constraints
-            .filter { !it.test(value) }
+            .filter { !it.test(context, value) }
             .map { constructHint(value, it) }
             .let { errors ->
                 if (errors.isEmpty()) {
@@ -116,15 +113,15 @@ internal class ValidationNode<T>(
             }
     }
 
-    private fun constructHint(value: T, it: Constraint<T>): String {
+    private fun constructHint(value: T, it: Constraint<C, T>): String {
         val replaceValue = it.hint.replace("{value}", value.toString())
         return it.templateValues
             .foldIndexed(replaceValue) { index, hint, templateValue -> hint.replace("{$index}", templateValue) }
     }
 
-    private fun applySubValidations(propertyValue: T, keyTransform: (String) -> String): ValidationResult<T> {
+    private fun applySubValidations(context: C, propertyValue: T, keyTransform: (String) -> String): ValidationResult<T> {
         return subValidations.fold(Valid(propertyValue)) { existingValidation: ValidationResult<T>, validation ->
-            val newValidation = validation.validate(propertyValue).mapError(keyTransform)
+            val newValidation = validation.validate(context, propertyValue).mapError(keyTransform)
             existingValidation.combineWith(newValidation)
         }
     }

--- a/src/commonMain/kotlin/io/konform/validation/jsonschema/JsonSchema.kt
+++ b/src/commonMain/kotlin/io/konform/validation/jsonschema/JsonSchema.kt
@@ -6,7 +6,7 @@ import kotlin.jvm.JvmName
 import kotlin.math.roundToInt
 
 inline fun <C, reified T> ValidationBuilder<C, *>.type() =
-    addSimpleConstraint(
+    addConstraint(
         "must be of the correct type"
     ) { it is T }
 
@@ -14,14 +14,14 @@ inline fun <C, reified T> ValidationBuilder<C, *>.type() =
 inline fun <reified T> ValidationBuilder<Unit, *>.type() = type<Unit, T>()
 
 fun <C, T> ValidationBuilder<C, T>.enum(vararg allowed: T) =
-    addSimpleConstraint(
+    addConstraint(
         "must be one of: {0}",
         allowed.joinToString("', '", "'", "'")
     ) { it in allowed }
 
 inline fun <C, reified T : Enum<T>> ValidationBuilder<C, String>.enum(): Constraint<*, String> {
     val enumNames = enumValues<T>().map { it.name }
-    return addSimpleConstraint(
+    return addConstraint(
         "must be one of: {0}",
         enumNames.joinToString("', '", "'", "'")
     ) { it in enumNames }
@@ -31,7 +31,7 @@ inline fun <C, reified T : Enum<T>> ValidationBuilder<C, String>.enum(): Constra
 inline fun <reified T : Enum<T>> ValidationBuilder<Unit, String>.enum(): Constraint<*, String> = enum<Unit, T>()
 
 fun <C, T> ValidationBuilder<C, T>.const(expected: T) =
-    addSimpleConstraint(
+    addConstraint(
         "must be {0}",
         expected?.let { "'$it'" } ?: "null"
     ) { expected == it }
@@ -40,35 +40,35 @@ fun <C, T> ValidationBuilder<C, T>.const(expected: T) =
 fun <C, T : Number> ValidationBuilder<C, T>.multipleOf(factor: Number): Constraint<C, T> {
     val factorAsDouble = factor.toDouble()
     require(factorAsDouble > 0) { "multipleOf requires the factor to be strictly larger than 0" }
-    return addSimpleConstraint("must be a multiple of '{0}'", factor.toString()) {
+    return addConstraint("must be a multiple of '{0}'", factor.toString()) {
         val division = it.toDouble() / factorAsDouble
         division.compareTo(division.roundToInt()) == 0
     }
 }
 
-fun <C, T : Number> ValidationBuilder<C, T>.maximum(maximumInclusive: Number) = addSimpleConstraint(
+fun <C, T : Number> ValidationBuilder<C, T>.maximum(maximumInclusive: Number) = addConstraint(
     "must be at most '{0}'",
     maximumInclusive.toString()
 ) { it.toDouble() <= maximumInclusive.toDouble() }
 
-fun <C, T : Number> ValidationBuilder<C, T>.exclusiveMaximum(maximumExclusive: Number) = addSimpleConstraint(
+fun <C, T : Number> ValidationBuilder<C, T>.exclusiveMaximum(maximumExclusive: Number) = addConstraint(
     "must be less than '{0}'",
     maximumExclusive.toString()
 ) { it.toDouble() < maximumExclusive.toDouble() }
 
-fun <C, T : Number> ValidationBuilder<C, T>.minimum(minimumInclusive: Number) = addSimpleConstraint(
+fun <C, T : Number> ValidationBuilder<C, T>.minimum(minimumInclusive: Number) = addConstraint(
     "must be at least '{0}'",
     minimumInclusive.toString()
 ) { it.toDouble() >= minimumInclusive.toDouble() }
 
-fun <C, T : Number> ValidationBuilder<C, T>.exclusiveMinimum(minimumExclusive: Number) = addSimpleConstraint(
+fun <C, T : Number> ValidationBuilder<C, T>.exclusiveMinimum(minimumExclusive: Number) = addConstraint(
     "must be greater than '{0}'",
     minimumExclusive.toString()
 ) { it.toDouble() > minimumExclusive.toDouble() }
 
 fun <C> ValidationBuilder<C, String>.minLength(length: Int): Constraint<C, String> {
     require(length >= 0) { IllegalArgumentException("minLength requires the length to be >= 0") }
-    return addSimpleConstraint(
+    return addConstraint(
         "must have at least {0} characters",
         length.toString()
     ) { it.length >= length }
@@ -76,7 +76,7 @@ fun <C> ValidationBuilder<C, String>.minLength(length: Int): Constraint<C, Strin
 
 fun <C> ValidationBuilder<C, String>.maxLength(length: Int): Constraint<*, String> {
     require(length >= 0) { IllegalArgumentException("maxLength requires the length to be >= 0") }
-    return addSimpleConstraint(
+    return addConstraint(
         "must have at most {0} characters",
         length.toString()
     ) { it.length <= length }
@@ -84,13 +84,13 @@ fun <C> ValidationBuilder<C, String>.maxLength(length: Int): Constraint<*, Strin
 
 fun <C> ValidationBuilder<C, String>.pattern(pattern: String) = pattern(pattern.toRegex())
 
-fun <C> ValidationBuilder<C, String>.pattern(pattern: Regex) = addSimpleConstraint(
+fun <C> ValidationBuilder<C, String>.pattern(pattern: Regex) = addConstraint(
     "must match the expected pattern",
     pattern.toString()
 ) { it.matches(pattern) }
 
 
-inline fun <C, reified T> ValidationBuilder<C, T>.minItems(minSize: Int): Constraint<C, T> = addSimpleConstraint(
+inline fun <C, reified T> ValidationBuilder<C, T>.minItems(minSize: Int): Constraint<C, T> = addConstraint(
     "must have at least {0} items",
     minSize.toString()
 ) {
@@ -103,7 +103,7 @@ inline fun <C, reified T> ValidationBuilder<C, T>.minItems(minSize: Int): Constr
 }
 
 
-inline fun <C, reified T> ValidationBuilder<C, T>.maxItems(maxSize: Int): Constraint<C, T> = addSimpleConstraint(
+inline fun <C, reified T> ValidationBuilder<C, T>.maxItems(maxSize: Int): Constraint<C, T> = addConstraint(
     "must have at most {0} items",
     maxSize.toString()
 ) {
@@ -121,7 +121,7 @@ inline fun <C, reified T: Map<*, *>> ValidationBuilder<C, T>.minProperties(minSi
 inline fun <C, reified T: Map<*, *>> ValidationBuilder<C, T>.maxProperties(maxSize: Int): Constraint<C, T> =
     maxItems(maxSize) hint "must have at most {0} properties"
 
-inline fun <C, reified T> ValidationBuilder<C, T>.uniqueItems(unique: Boolean): Constraint<C, T> = addSimpleConstraint(
+inline fun <C, reified T> ValidationBuilder<C, T>.uniqueItems(unique: Boolean): Constraint<C, T> = addConstraint(
     "all items must be unique"
 ) {
     !unique || when (it) {

--- a/src/commonTest/kotlin/io/konform/validation/JSONSchemaStyleConstraintsTest.kt
+++ b/src/commonTest/kotlin/io/konform/validation/JSONSchemaStyleConstraintsTest.kt
@@ -45,6 +45,18 @@ class JSONSchemaStyleConstraintsTest {
     }
 
     @Test
+    fun typeConstraintWithContext() {
+        val anyValidation = Validation<String, Any> { type<String, String>() }
+        assertEquals(
+            Valid("This is a string"),
+            anyValidation("c", "This is a string"))
+
+        assertEquals(1, countFieldsWithErrors(anyValidation("c", 1)))
+        assertEquals(1, countFieldsWithErrors(anyValidation("c", 1.0)))
+        assertEquals(1, countFieldsWithErrors(anyValidation("c", true)))
+    }
+
+    @Test
     fun nullableTypeConstraint() {
         val anyValidation = Validation<Any?> { type<String?>() }
         assertEquals<ValidationResult<Any?>>(
@@ -84,8 +96,15 @@ class JSONSchemaStyleConstraintsTest {
         assertEquals(Valid("SYNACK"), stringifiedEnumValidation("SYNACK"))
         assertEquals(1, countFieldsWithErrors(stringifiedEnumValidation("ASDF")))
 
+        val stringifiedEnumValidationWithContext = Validation<Int, String> { enum<Int, TCPPacket>() }
+        assertEquals(Valid("SYN"), stringifiedEnumValidationWithContext(1, "SYN"))
+        assertEquals(Valid("ACK"), stringifiedEnumValidationWithContext(2, "ACK"))
+        assertEquals(Valid("SYNACK"), stringifiedEnumValidationWithContext(3, "SYNACK"))
+        assertEquals(1, countFieldsWithErrors(stringifiedEnumValidationWithContext(4, "ASDF")))
+
         assertEquals("must be one of: 'SYN', 'ACK'", partialEnumValidation(SYNACK).get()!![0])
         assertEquals("must be one of: 'SYN', 'ACK', 'SYNACK'", stringifiedEnumValidation("").get()!![0])
+        assertEquals("must be one of: 'SYN', 'ACK', 'SYNACK'", stringifiedEnumValidationWithContext(1, "").get()!![0])
     }
 
     @Test

--- a/src/commonTest/kotlin/io/konform/validation/ValidationBuilderTest.kt
+++ b/src/commonTest/kotlin/io/konform/validation/ValidationBuilderTest.kt
@@ -8,16 +8,16 @@ import kotlin.test.assertTrue
 class ValidationBuilderTest {
 
     // Some example constraints for Testing
-    fun ValidationBuilder<String>.minLength(minValue: Int) =
-        addConstraint("must have at least {0} characters", minValue.toString()) { it.length >= minValue }
+    fun ValidationBuilder<Unit, String>.minLength(minValue: Int) =
+        addSimpleConstraint("must have at least {0} characters", minValue.toString()) { it.length >= minValue }
 
-    fun ValidationBuilder<String>.maxLength(minValue: Int) =
-        addConstraint("must have at most {0} characters", minValue.toString()) { it.length <= minValue }
+    fun ValidationBuilder<Unit, String>.maxLength(minValue: Int) =
+        addSimpleConstraint("must have at most {0} characters", minValue.toString()) { it.length <= minValue }
 
-    fun ValidationBuilder<String>.matches(regex: Regex) =
-        addConstraint("must have correct format") { it.contains(regex) }
+    fun ValidationBuilder<Unit, String>.matches(regex: Regex) =
+        addSimpleConstraint("must have correct format") { it.contains(regex) }
 
-    fun ValidationBuilder<String>.containsANumber() =
+    fun ValidationBuilder<Unit, String>.containsANumber() =
         matches("[0-9]".toRegex()) hint "must have at least one number"
 
     @Test
@@ -30,6 +30,15 @@ class ValidationBuilderTest {
 
         Register(password = "a").let { assertEquals(Valid(it), oneValidation(it)) }
         Register(password = "").let { assertEquals(1, countErrors(oneValidation(it), Register::password)) }
+    }
+
+    @Test
+    fun singleValidationWithContext() {
+        val validation = Validation<Set<String>, String> {
+            addConstraint("This value is not allowed!") { context, value -> context.contains(value) }
+        }
+        "a".let { assertEquals(Valid(it), validation(setOf("a", "b"), it)) }
+        "c".let { assertEquals(1, countErrors(validation(setOf("a", "b"), it))) }
     }
 
     @Test

--- a/src/commonTest/kotlin/io/konform/validation/ValidationBuilderTest.kt
+++ b/src/commonTest/kotlin/io/konform/validation/ValidationBuilderTest.kt
@@ -9,13 +9,13 @@ class ValidationBuilderTest {
 
     // Some example constraints for Testing
     fun ValidationBuilder<Unit, String>.minLength(minValue: Int) =
-        addSimpleConstraint("must have at least {0} characters", minValue.toString()) { it.length >= minValue }
+        addConstraint("must have at least {0} characters", minValue.toString()) { it.length >= minValue }
 
     fun ValidationBuilder<Unit, String>.maxLength(minValue: Int) =
-        addSimpleConstraint("must have at most {0} characters", minValue.toString()) { it.length <= minValue }
+        addConstraint("must have at most {0} characters", minValue.toString()) { it.length <= minValue }
 
     fun ValidationBuilder<Unit, String>.matches(regex: Regex) =
-        addSimpleConstraint("must have correct format") { it.contains(regex) }
+        addConstraint("must have correct format") { it.contains(regex) }
 
     fun ValidationBuilder<Unit, String>.containsANumber() =
         matches("[0-9]".toRegex()) hint "must have at least one number"
@@ -35,7 +35,7 @@ class ValidationBuilderTest {
     @Test
     fun singleValidationWithContext() {
         val validation = Validation<Set<String>, String> {
-            addConstraint("This value is not allowed!") { context, value -> context.contains(value) }
+            addConstraint("This value is not allowed!") { value -> this.contains(value) }
         }
         "a".let { assertEquals(Valid(it), validation(setOf("a", "b"), it)) }
         "c".let { assertEquals(1, countErrors(validation(setOf("a", "b"), it))) }


### PR DESCRIPTION
Currently when you want to do a database call or check a value against some set of data, your only option is to wrap the "context" in the builder, e.g.

```
val allowedValues: Set<String> = calculateAllowedValues()
val validation = Validation<String> {
    addConstraint("This value is not allowed!") { allowedValues.contains(it) }
}
validation("wim")
```

The result is that a validation is tightly coupled to its "context". This is troublesome especially when the "context" is not constant.

Prettier would be:
```
val validation = Validation<Set<String>, String> {
    addConstraint("This value is not allowed!") { context, value -> context.contains(value) }
}
val allowedValues: Set<String> = calculateAllowedValues()
validation(allowedValues, "wim")
```


The changes in this branch allow the user to use a piece of context, with almost no breaking changes for those that don't need any context (the special case, with `Unit` context). The only breaking change is when you define your own extension function on a `ValidationBuilder`.

```
fun ValidationBuilder<String>.myOwnConstraintBuilder() = ...
// becomes:
fun ValidationBuilder<Unit, String>.myOwnConstraintBuilder() = ...
```

