### PR TITLE
Compose validation builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ You can define validations for nested classes and use them for new validations
 
 ```Kotlin
 val ageCheck = Validation<UserProfile> {
-    UserProfile::age required {
+    UserProfile::age required with {
         minimum(18)
     }
 }
@@ -128,8 +128,8 @@ data class Event(
 val validateEvent = Validation<Event> {
     Event::organizer {
         // even though the email is nullable you can force it to be set in the validation
-        Person::email required {
-            pattern(".+@bigcorp.com") hint "Organizers must have a BigCorp email address"
+        Person::email required with {
+            pattern("\\w+@bigcorp.com") hint staticHint("Organizers must have a BigCorp email address")
         }
     }
 
@@ -144,22 +144,22 @@ val validateEvent = Validation<Event> {
             minLength(2)
         }
         Person::age {
-            minimum(18) hint "Attendees must be 18 years or older"
+            minimum(18) hint stringHint("Attendees must be 18 years or older")
         }
         // Email is optional but if it is set it must be valid
         Person::email ifPresent {
-            pattern(".+@.+\..+") hint "Please provide a valid email address (optional)"
+            pattern("\\w+@\\w+\\.\\w+") hint stringHint("Please provide a valid email address (optional)")
         }
     }
 
     // validation on the ticketPrices Map as a whole
     Event::ticketPrices {
-        minItems(1) hint "Provide at least one ticket price"
+        minItems(1) hint stringHint("Provide at least one ticket price")
     }
 
     // validations for the individual entries
     Event::ticketPrices onEach {
-        // Tickets may be free in which case they are null
+        // Tickets may be free
         Entry<String, Double?>::value ifPresent {
             minimum(0.01)
         }

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ val validateEvent = Validation<Event> {
     Event::organizer {
         // even though the email is nullable you can force it to be set in the validation
         Person::email required with {
-            pattern("\\w+@bigcorp.com") hint staticHint("Organizers must have a BigCorp email address")
+            pattern("\\w+@bigcorp.com") hint "Organizers must have a BigCorp email address"
         }
     }
 
@@ -144,17 +144,17 @@ val validateEvent = Validation<Event> {
             minLength(2)
         }
         Person::age {
-            minimum(18) hint stringHint("Attendees must be 18 years or older")
+            minimum(18) hint "Attendees must be 18 years or older"
         }
         // Email is optional but if it is set it must be valid
         Person::email ifPresent {
-            pattern("\\w+@\\w+\\.\\w+") hint stringHint("Please provide a valid email address (optional)")
+            pattern("\\w+@\\w+\\.\\w+") hint "Please provide a valid email address (optional)"
         }
     }
 
     // validation on the ticketPrices Map as a whole
     Event::ticketPrices {
-        minItems(1) hint stringHint("Provide at least one ticket price")
+        minItems(1) hint "Provide at least one ticket price"
     }
 
     // validations for the individual entries

--- a/src/commonMain/kotlin/io/konform/validation/Validation.kt
+++ b/src/commonMain/kotlin/io/konform/validation/Validation.kt
@@ -6,20 +6,20 @@ import kotlin.jvm.JvmName
 interface Validation<C, T, E> {
 
     companion object {
-        operator fun <C, T, E> invoke(requiredError: E, init: ValidationBuilder<C, T, E>.() -> Unit): Validation<C, T, E> {
-            val builder = ValidationNodeBuilder<C, T, E>(requiredError)
+        operator fun <C, T, E> invoke(init: ValidationBuilder<C, T, E>.() -> Unit): Validation<C, T, E> {
+            val builder = ValidationNodeBuilder<C, T, E>()
             return builder.apply(init).build()
         }
 
         @JvmName("contextInvoke")
         operator fun <C, T> invoke(init: ValidationBuilder<C, T, String>.() -> Unit): Validation<C, T, String> {
-            val builder = ValidationNodeBuilder<C, T, String>("is required")
+            val builder = ValidationNodeBuilder<C, T, String>()
             return builder.apply(init).build()
         }
 
         @JvmName("simpleInvoke")
         operator fun <T> invoke(init: ValidationBuilder<Unit, T, String>.() -> Unit): Validation<Unit, T, String> {
-            val builder = ValidationNodeBuilder<Unit, T, String>("is required")
+            val builder = ValidationNodeBuilder<Unit, T, String>()
             return builder.apply(init).build()
         }
     }

--- a/src/commonMain/kotlin/io/konform/validation/Validation.kt
+++ b/src/commonMain/kotlin/io/konform/validation/Validation.kt
@@ -3,23 +3,29 @@ package io.konform.validation
 import io.konform.validation.internal.ValidationNodeBuilder
 import kotlin.jvm.JvmName
 
-interface Validation<C, T> {
+interface Validation<C, T, E> {
 
     companion object {
-        operator fun <C, T> invoke(init: ValidationBuilder<C, T>.() -> Unit): Validation<C, T> {
-            val builder = ValidationNodeBuilder<C, T>()
+        operator fun <C, T, E> invoke(requiredError: E, init: ValidationBuilder<C, T, E>.() -> Unit): Validation<C, T, E> {
+            val builder = ValidationNodeBuilder<C, T, E>(requiredError)
+            return builder.apply(init).build()
+        }
+
+        @JvmName("contextInvoke")
+        operator fun <C, T> invoke(init: ValidationBuilder<C, T, String>.() -> Unit): Validation<C, T, String> {
+            val builder = ValidationNodeBuilder<C, T, String>("is required")
             return builder.apply(init).build()
         }
 
         @JvmName("simpleInvoke")
-        operator fun <T> invoke(init: ValidationBuilder<Unit, T>.() -> Unit): Validation<Unit, T> {
-            val builder = ValidationNodeBuilder<Unit, T>()
+        operator fun <T> invoke(init: ValidationBuilder<Unit, T, String>.() -> Unit): Validation<Unit, T, String> {
+            val builder = ValidationNodeBuilder<Unit, T, String>("is required")
             return builder.apply(init).build()
         }
     }
 
-    fun validate(context: C, value: T): ValidationResult<T>
+    fun validate(context: C, value: T): ValidationResult<E, T>
     operator fun invoke(context: C, value: T) = validate(context, value)
 }
 
-operator fun <T> Validation<Unit, T>.invoke(value: T) = validate(Unit, value)
+operator fun <T, E> Validation<Unit, T, E>.invoke(value: T) = validate(Unit, value)

--- a/src/commonMain/kotlin/io/konform/validation/Validation.kt
+++ b/src/commonMain/kotlin/io/konform/validation/Validation.kt
@@ -1,19 +1,27 @@
 package io.konform.validation
 
 import io.konform.validation.internal.ValidationBuilderImpl
+import kotlin.jvm.JvmName
 
-interface Validation<T> {
+interface Validation<C, T> {
 
     companion object {
-        operator fun <T> invoke(init: ValidationBuilder<T>.() -> Unit): Validation<T> {
-            val builder = ValidationBuilderImpl<T>()
+        operator fun <C, T> invoke(init: ValidationBuilder<C, T>.() -> Unit): Validation<C, T> {
+            val builder = ValidationBuilderImpl<C, T>()
+            return builder.apply(init).build()
+        }
+
+        @JvmName("simpleInvoke")
+        operator fun <T> invoke(init: ValidationBuilder<Unit, T>.() -> Unit): Validation<Unit, T> {
+            val builder = ValidationBuilderImpl<Unit, T>()
             return builder.apply(init).build()
         }
     }
 
-    fun validate(value: T): ValidationResult<T>
-    operator fun invoke(value: T) = validate(value)
+    fun validate(context: C, value: T): ValidationResult<T>
+    operator fun invoke(context: C, value: T) = validate(context, value)
 }
 
+operator fun <T> Validation<Unit, T>.invoke(value: T) = validate(Unit, value)
 
-class Constraint<R> internal constructor(val hint: String, val templateValues: List<String>, val test: (R) -> Boolean)
+class Constraint<C, R> internal constructor(val hint: String, val templateValues: List<String>, val test: (C, R) -> Boolean)

--- a/src/commonMain/kotlin/io/konform/validation/Validation.kt
+++ b/src/commonMain/kotlin/io/konform/validation/Validation.kt
@@ -1,19 +1,19 @@
 package io.konform.validation
 
-import io.konform.validation.internal.ValidationBuilderImpl
+import io.konform.validation.internal.ValidationNodeBuilder
 import kotlin.jvm.JvmName
 
 interface Validation<C, T> {
 
     companion object {
         operator fun <C, T> invoke(init: ValidationBuilder<C, T>.() -> Unit): Validation<C, T> {
-            val builder = ValidationBuilderImpl<C, T>()
+            val builder = ValidationNodeBuilder<C, T>()
             return builder.apply(init).build()
         }
 
         @JvmName("simpleInvoke")
         operator fun <T> invoke(init: ValidationBuilder<Unit, T>.() -> Unit): Validation<Unit, T> {
-            val builder = ValidationBuilderImpl<Unit, T>()
+            val builder = ValidationNodeBuilder<Unit, T>()
             return builder.apply(init).build()
         }
     }
@@ -23,5 +23,3 @@ interface Validation<C, T> {
 }
 
 operator fun <T> Validation<Unit, T>.invoke(value: T) = validate(Unit, value)
-
-class Constraint<C, R> internal constructor(val hint: String, val templateValues: List<String>, val test: (C, R) -> Boolean)

--- a/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
@@ -1,54 +1,73 @@
 package io.konform.validation
 
-import io.konform.validation.internal.ArrayValidation
-import io.konform.validation.internal.IterableValidation
-import io.konform.validation.internal.MapValidation
-import io.konform.validation.internal.OptionalValidation
-import io.konform.validation.internal.RequiredValidation
-import io.konform.validation.internal.ValidationBuilderImpl
+import io.konform.validation.internal.*
 import kotlin.jvm.JvmName
+import kotlin.reflect.KFunction1
 import kotlin.reflect.KProperty1
 
 @DslMarker
 private annotation class ValidationScope
 
 @ValidationScope
-abstract class ValidationBuilder<C, T> {
-    abstract fun build(): Validation<C, T>
-    abstract fun addConstraint(errorMessage: String, vararg templateValues: String, test: C.(T) -> Boolean): Constraint<C, T>
-    abstract infix fun Constraint<C, T>.hint(hint: String): Constraint<C, T>
+abstract class ValidationBuilder<C, T> : ComposableBuilder<C, T> {
+    abstract override fun build(): Validation<C, T>
+
+    abstract fun addConstraint(hint: String, vararg values: String, test: C.(T) -> Boolean): ConstraintBuilder
+
     abstract operator fun <R> KProperty1<T, R>.invoke(init: ValidationBuilder<C, R>.() -> Unit)
-    internal abstract fun <R> onEachIterable(prop: KProperty1<T, Iterable<R>>, init: ValidationBuilder<C, R>.() -> Unit)
+    abstract operator fun <R> KFunction1<T, R>.invoke(init: ValidationBuilder<C, R>.() -> Unit)
+
+    internal abstract fun <R> onEachIterable(name: String, mapFn: (T) -> Iterable<R>, init: ValidationBuilder<C, R>.() -> Unit)
     @JvmName("onEachIterable")
-    infix fun <R> KProperty1<T, Iterable<R>>.onEach(init: ValidationBuilder<C, R>.() -> Unit) = onEachIterable(this, init)
-    internal abstract fun <R> onEachArray(prop: KProperty1<T, Array<R>>, init: ValidationBuilder<C, R>.() -> Unit)
+    infix fun <R> KProperty1<T, Iterable<R>>.onEach(init: ValidationBuilder<C, R>.() -> Unit) = onEachIterable(this.name, this, init)
+    @JvmName("onEachIterable")
+    infix fun <R> KFunction1<T, Iterable<R>>.onEach(init: ValidationBuilder<C, R>.() -> Unit) = onEachIterable(this.name, this, init)
+
+    internal abstract fun <R> onEachArray(name: String, mapFn: (T) -> Array<R>, init: ValidationBuilder<C, R>.() -> Unit)
     @JvmName("onEachArray")
-    infix fun <R> KProperty1<T, Array<R>>.onEach(init: ValidationBuilder<C, R>.() -> Unit) = onEachArray(this, init)
-    internal abstract fun <K, V> onEachMap(prop: KProperty1<T, Map<K, V>>, init: ValidationBuilder<C, Map.Entry<K, V>>.() -> Unit)
+    infix fun <R> KProperty1<T, Array<R>>.onEach(init: ValidationBuilder<C, R>.() -> Unit) = onEachArray(this.name, this, init)
+    @JvmName("onEachArray")
+    infix fun <R> KFunction1<T, Array<R>>.onEach(init: ValidationBuilder<C, R>.() -> Unit) = onEachArray(this.name, this, init)
+
+    internal abstract fun <K, V> onEachMap(name: String, mapFn: (T) -> Map<K, V>, init: ValidationBuilder<C, Map.Entry<K, V>>.() -> Unit)
     @JvmName("onEachMap")
-    infix fun <K, V> KProperty1<T, Map<K, V>>.onEach(init: ValidationBuilder<C, Map.Entry<K, V>>.() -> Unit) = onEachMap(this, init)
-    abstract infix fun <R> KProperty1<T, R?>.ifPresent(init: ValidationBuilder<C, R>.() -> Unit)
-    abstract infix fun <R> KProperty1<T, R?>.required(init: ValidationBuilder<C, R>.() -> Unit)
-    abstract fun run(validation: Validation<C, T>)
+    infix fun <K, V> KProperty1<T, Map<K, V>>.onEach(init: ValidationBuilder<C, Map.Entry<K, V>>.() -> Unit) = onEachMap(this.name, this, init)
+    @JvmName("onEachMap")
+    infix fun <K, V> KFunction1<T, Map<K, V>>.onEach(init: ValidationBuilder<C, Map.Entry<K, V>>.() -> Unit) = onEachMap(this.name, this, init)
+
+    internal abstract fun <R : Any> ifPresent(name: String, mapFn: (T) -> R?, init: ValidationBuilder<C, R>.() -> Unit)
+    infix fun <R : Any> KProperty1<T, R?>.ifPresent(init: ValidationBuilder<C, R>.() -> Unit) = ifPresent(this.name, this, init)
+    infix fun <R : Any> KFunction1<T, R?>.ifPresent(init: ValidationBuilder<C, R>.() -> Unit) = ifPresent(this.name, this, init)
+
+    internal abstract fun <R : Any> required(name: String, mapFn: (T) -> R?, init: ValidationBuilder<C, R>.() -> Unit)
+    infix fun <R : Any> KProperty1<T, R?>.required(init: ValidationBuilder<C, R>.() -> Unit) = required(this.name, this, init)
+    infix fun <R : Any> KFunction1<T, R?>.required(init: ValidationBuilder<C, R>.() -> Unit) = required(this.name, this, init)
+
     abstract fun <S> run(validation: Validation<S, T>, map: (C) -> S)
+    fun run(validation: Validation<C, T>) = run(validation, ::identity)
+
     abstract val <R> KProperty1<T, R>.has: ValidationBuilder<C, R>
 }
 
+interface ConstraintBuilder {
+    infix fun hint(hint: String) : ConstraintBuilder
+}
+
 fun <C, T : Any> ValidationBuilder<C, T?>.ifPresent(init: ValidationBuilder<C, T>.() -> Unit) {
-    val builder = ValidationBuilderImpl<C, T>()
+    val builder = ValidationNodeBuilder<C, T>()
     init(builder)
     run(OptionalValidation(builder.build()))
 }
 
 fun <C, T : Any> ValidationBuilder<C, T?>.required(init: ValidationBuilder<C, T>.() -> Unit) {
-    val builder = ValidationBuilderImpl<C, T>()
+    val builder = ValidationNodeBuilder<C, T>()
     init(builder)
     run(RequiredValidation(builder.build()))
 }
 
 @JvmName("onEachIterable")
 fun <C, S, T : Iterable<S>> ValidationBuilder<C, T>.onEach(init: ValidationBuilder<C, S>.() -> Unit) {
-    val builder = ValidationBuilderImpl<C, S>()
+    val builder = ValidationNodeBuilder<C, S>()
     init(builder)
     @Suppress("UNCHECKED_CAST")
     run(IterableValidation(builder.build()) as Validation<C, T>)
@@ -56,7 +75,7 @@ fun <C, S, T : Iterable<S>> ValidationBuilder<C, T>.onEach(init: ValidationBuild
 
 @JvmName("onEachArray")
 fun <C, T> ValidationBuilder<C, Array<T>>.onEach(init: ValidationBuilder<C, T>.() -> Unit) {
-    val builder = ValidationBuilderImpl<C, T>()
+    val builder = ValidationNodeBuilder<C, T>()
     init(builder)
     @Suppress("UNCHECKED_CAST")
     run(ArrayValidation(builder.build()) as Validation<C, Array<T>>)
@@ -64,7 +83,7 @@ fun <C, T> ValidationBuilder<C, Array<T>>.onEach(init: ValidationBuilder<C, T>.(
 
 @JvmName("onEachMap")
 fun <C, K, V, T : Map<K, V>> ValidationBuilder<C, T>.onEach(init: ValidationBuilder<C, Map.Entry<K, V>>.() -> Unit) {
-    val builder = ValidationBuilderImpl<C, Map.Entry<K, V>>()
+    val builder = ValidationNodeBuilder<C, Map.Entry<K, V>>()
     init(builder)
     @Suppress("UNCHECKED_CAST")
     run(MapValidation(builder.build()) as Validation<C, T>)

--- a/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
@@ -56,9 +56,14 @@ abstract class ValidationBuilder<C, T, E> : ComposableBuilder<C, T, E> {
     abstract val <R> KProperty1<T, R>.has: ValidationBuilder<C, R, E>
 }
 
+fun <C, T> ValidationBuilder<C, T, String>.addConstraint(hint: String, vararg values: Any, test: C.(T) -> Boolean): ConstraintBuilder<C, T, String> =
+    addConstraint(stringHint(hint), values) { test(it) }
+
 interface ConstraintBuilder<C, T, E> {
     infix fun hint(hint: HintBuilder<C, T, E>) : ConstraintBuilder<C, T, E>
 }
+
+infix fun <C,T> ConstraintBuilder<C,T,String>.hint(hint: String) = hint(stringHint(hint))
 
 interface HintedRequiredBuilder<C, T, E> {
     val hint: HintBuilder<C, T?, E>

--- a/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
@@ -100,10 +100,12 @@ fun <C, K, V, T : Map<K, V>, E> ValidationBuilder<C, T, E>.onEach(init: Validati
 typealias HintArguments = List<Any>
 typealias HintBuilder<C, T, E> = C.(T, HintArguments) -> E
 
-fun <C, T> stringHintBuilder(template: String): HintBuilder<C, T, String> = { value, args ->
+fun <C, T> stringHint(template: String): HintBuilder<C, T, String> = { value, args ->
     args
         .map(Any::toString)
         .foldIndexed(template.replace("{value}", value.toString())) { index, acc, arg ->
             acc.replace("{$index}", arg)
         }
 }
+
+fun <C, T, E> staticHint(e: E): HintBuilder<C, T, E> = { _, _ -> e }

--- a/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
@@ -57,7 +57,7 @@ abstract class ValidationBuilder<C, T, E> : ComposableBuilder<C, T, E> {
 }
 
 fun <C, T> ValidationBuilder<C, T, String>.addConstraint(hint: String, vararg values: Any, test: C.(T) -> Boolean): ConstraintBuilder<C, T, String> =
-    addConstraint(stringHint(hint), values) { test(it) }
+    addConstraint(stringHint(hint), *values) { test(it) }
 
 interface ConstraintBuilder<C, T, E> {
     infix fun hint(hint: HintBuilder<C, T, E>) : ConstraintBuilder<C, T, E>

--- a/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
@@ -16,8 +16,6 @@ private annotation class ValidationScope
 abstract class ValidationBuilder<C, T> {
     abstract fun build(): Validation<C, T>
     abstract fun addConstraint(errorMessage: String, vararg templateValues: String, test: C.(T) -> Boolean): Constraint<C, T>
-//    fun addConstraint(errorMessage: String, vararg templateValues: String, test: (T) -> Boolean): Constraint<C, T> =
-//        addConstraint(errorMessage, *templateValues) { _, value -> test(value) }
     abstract infix fun Constraint<C, T>.hint(hint: String): Constraint<C, T>
     abstract operator fun <R> KProperty1<T, R>.invoke(init: ValidationBuilder<C, R>.() -> Unit)
     internal abstract fun <R> onEachIterable(prop: KProperty1<T, Iterable<R>>, init: ValidationBuilder<C, R>.() -> Unit)

--- a/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
@@ -32,6 +32,7 @@ abstract class ValidationBuilder<C, T> {
     abstract infix fun <R> KProperty1<T, R?>.ifPresent(init: ValidationBuilder<C, R>.() -> Unit)
     abstract infix fun <R> KProperty1<T, R?>.required(init: ValidationBuilder<C, R>.() -> Unit)
     abstract fun run(validation: Validation<C, T>)
+    abstract fun <S> run(validation: Validation<S, T>, map: (C) -> S)
     abstract val <R> KProperty1<T, R>.has: ValidationBuilder<C, R>
 }
 

--- a/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
@@ -15,9 +15,9 @@ private annotation class ValidationScope
 @ValidationScope
 abstract class ValidationBuilder<C, T> {
     abstract fun build(): Validation<C, T>
-    abstract fun addConstraint(errorMessage: String, vararg templateValues: String, test: (C, T) -> Boolean): Constraint<C, T>
-    fun addSimpleConstraint(errorMessage: String, vararg templateValues: String, test: (T) -> Boolean): Constraint<C, T> =
-        addConstraint(errorMessage, *templateValues) { _, value -> test(value) }
+    abstract fun addConstraint(errorMessage: String, vararg templateValues: String, test: C.(T) -> Boolean): Constraint<C, T>
+//    fun addConstraint(errorMessage: String, vararg templateValues: String, test: (T) -> Boolean): Constraint<C, T> =
+//        addConstraint(errorMessage, *templateValues) { _, value -> test(value) }
     abstract infix fun Constraint<C, T>.hint(hint: String): Constraint<C, T>
     abstract operator fun <R> KProperty1<T, R>.invoke(init: ValidationBuilder<C, R>.() -> Unit)
     internal abstract fun <R> onEachIterable(prop: KProperty1<T, Iterable<R>>, init: ValidationBuilder<C, R>.() -> Unit)

--- a/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
@@ -9,82 +9,95 @@ import kotlin.reflect.KProperty1
 private annotation class ValidationScope
 
 @ValidationScope
-abstract class ValidationBuilder<C, T> : ComposableBuilder<C, T> {
-    abstract override fun build(): Validation<C, T>
+abstract class ValidationBuilder<C, T, E> : ComposableBuilder<C, T, E> {
+    abstract val requiredError: E
+    abstract override fun build(): Validation<C, T, E>
 
-    abstract fun addConstraint(hint: String, vararg values: String, test: C.(T) -> Boolean): ConstraintBuilder
+    abstract fun addConstraint(hint: HintBuilder<C, T, E>, vararg values: Any, test: C.(T) -> Boolean): ConstraintBuilder<C, T, E>
 
-    abstract operator fun <R> KProperty1<T, R>.invoke(init: ValidationBuilder<C, R>.() -> Unit)
-    abstract operator fun <R> KFunction1<T, R>.invoke(init: ValidationBuilder<C, R>.() -> Unit)
+    abstract operator fun <R> KProperty1<T, R>.invoke(init: ValidationBuilder<C, R, E>.() -> Unit)
+    abstract operator fun <R> KFunction1<T, R>.invoke(init: ValidationBuilder<C, R, E>.() -> Unit)
 
-    internal abstract fun <R> onEachIterable(name: String, mapFn: (T) -> Iterable<R>, init: ValidationBuilder<C, R>.() -> Unit)
+    internal abstract fun <R> onEachIterable(name: String, mapFn: (T) -> Iterable<R>, init: ValidationBuilder<C, R, E>.() -> Unit)
     @JvmName("onEachIterable")
-    infix fun <R> KProperty1<T, Iterable<R>>.onEach(init: ValidationBuilder<C, R>.() -> Unit) = onEachIterable(this.name, this, init)
+    infix fun <R> KProperty1<T, Iterable<R>>.onEach(init: ValidationBuilder<C, R, E>.() -> Unit) = onEachIterable(this.name, this, init)
     @JvmName("onEachIterable")
-    infix fun <R> KFunction1<T, Iterable<R>>.onEach(init: ValidationBuilder<C, R>.() -> Unit) = onEachIterable(this.name, this, init)
+    infix fun <R> KFunction1<T, Iterable<R>>.onEach(init: ValidationBuilder<C, R, E>.() -> Unit) = onEachIterable(this.name, this, init)
 
-    internal abstract fun <R> onEachArray(name: String, mapFn: (T) -> Array<R>, init: ValidationBuilder<C, R>.() -> Unit)
+    internal abstract fun <R> onEachArray(name: String, mapFn: (T) -> Array<R>, init: ValidationBuilder<C, R, E>.() -> Unit)
     @JvmName("onEachArray")
-    infix fun <R> KProperty1<T, Array<R>>.onEach(init: ValidationBuilder<C, R>.() -> Unit) = onEachArray(this.name, this, init)
+    infix fun <R> KProperty1<T, Array<R>>.onEach(init: ValidationBuilder<C, R, E>.() -> Unit) = onEachArray(this.name, this, init)
     @JvmName("onEachArray")
-    infix fun <R> KFunction1<T, Array<R>>.onEach(init: ValidationBuilder<C, R>.() -> Unit) = onEachArray(this.name, this, init)
+    infix fun <R> KFunction1<T, Array<R>>.onEach(init: ValidationBuilder<C, R, E>.() -> Unit) = onEachArray(this.name, this, init)
 
-    internal abstract fun <K, V> onEachMap(name: String, mapFn: (T) -> Map<K, V>, init: ValidationBuilder<C, Map.Entry<K, V>>.() -> Unit)
+    internal abstract fun <K, V> onEachMap(name: String, mapFn: (T) -> Map<K, V>, init: ValidationBuilder<C, Map.Entry<K, V>, E>.() -> Unit)
     @JvmName("onEachMap")
-    infix fun <K, V> KProperty1<T, Map<K, V>>.onEach(init: ValidationBuilder<C, Map.Entry<K, V>>.() -> Unit) = onEachMap(this.name, this, init)
+    infix fun <K, V> KProperty1<T, Map<K, V>>.onEach(init: ValidationBuilder<C, Map.Entry<K, V>, E>.() -> Unit) = onEachMap(this.name, this, init)
     @JvmName("onEachMap")
-    infix fun <K, V> KFunction1<T, Map<K, V>>.onEach(init: ValidationBuilder<C, Map.Entry<K, V>>.() -> Unit) = onEachMap(this.name, this, init)
+    infix fun <K, V> KFunction1<T, Map<K, V>>.onEach(init: ValidationBuilder<C, Map.Entry<K, V>, E>.() -> Unit) = onEachMap(this.name, this, init)
 
-    internal abstract fun <R : Any> ifPresent(name: String, mapFn: (T) -> R?, init: ValidationBuilder<C, R>.() -> Unit)
-    infix fun <R : Any> KProperty1<T, R?>.ifPresent(init: ValidationBuilder<C, R>.() -> Unit) = ifPresent(this.name, this, init)
-    infix fun <R : Any> KFunction1<T, R?>.ifPresent(init: ValidationBuilder<C, R>.() -> Unit) = ifPresent(this.name, this, init)
+    internal abstract fun <R : Any> ifPresent(name: String, mapFn: (T) -> R?, init: ValidationBuilder<C, R, E>.() -> Unit)
+    infix fun <R : Any> KProperty1<T, R?>.ifPresent(init: ValidationBuilder<C, R, E>.() -> Unit) = ifPresent(this.name, this, init)
+    infix fun <R : Any> KFunction1<T, R?>.ifPresent(init: ValidationBuilder<C, R, E>.() -> Unit) = ifPresent(this.name, this, init)
 
-    internal abstract fun <R : Any> required(name: String, mapFn: (T) -> R?, init: ValidationBuilder<C, R>.() -> Unit)
-    infix fun <R : Any> KProperty1<T, R?>.required(init: ValidationBuilder<C, R>.() -> Unit) = required(this.name, this, init)
-    infix fun <R : Any> KFunction1<T, R?>.required(init: ValidationBuilder<C, R>.() -> Unit) = required(this.name, this, init)
+    internal abstract fun <R : Any> required(name: String, hint: HintBuilder<C, R?, E>, mapFn: (T) -> R?, init: ValidationBuilder<C, R, E>.() -> Unit): ConstraintBuilder<C, R?, E>
+    infix fun <R : Any> KProperty1<T, R?>.required(init: ValidationBuilder<C, R, E>.() -> Unit): ConstraintBuilder<C, R?, E> = required(this.name, { _, _ -> requiredError }, this, init)
+    infix fun <R : Any> KFunction1<T, R?>.required(init: ValidationBuilder<C, R, E>.() -> Unit): ConstraintBuilder<C, R?, E> = required(this.name, { _, _ -> requiredError }, this, init)
 
-    abstract fun <S> run(validation: Validation<S, T>, map: (C) -> S)
-    fun run(validation: Validation<C, T>) = run(validation, ::identity)
+    abstract fun <S> run(validation: Validation<S, T, E>, map: (C) -> S)
+    fun run(validation: Validation<C, T, E>) = run(validation, ::identity)
 
-    abstract val <R> KProperty1<T, R>.has: ValidationBuilder<C, R>
+    abstract val <R> KProperty1<T, R>.has: ValidationBuilder<C, R, E>
 }
 
-interface ConstraintBuilder {
-    infix fun hint(hint: String) : ConstraintBuilder
+interface ConstraintBuilder<C, T, E> {
+    infix fun hint(hint: HintBuilder<C, T, E>) : ConstraintBuilder<C, T, E>
 }
 
-fun <C, T : Any> ValidationBuilder<C, T?>.ifPresent(init: ValidationBuilder<C, T>.() -> Unit) {
-    val builder = ValidationNodeBuilder<C, T>()
+fun <C, T : Any, E> ValidationBuilder<C, T?, E>.ifPresent(init: ValidationBuilder<C, T, E>.() -> Unit) {
+    val builder = ValidationNodeBuilder<C, T, E>(this.requiredError)
     init(builder)
     run(OptionalValidation(builder.build()))
 }
 
-fun <C, T : Any> ValidationBuilder<C, T?>.required(init: ValidationBuilder<C, T>.() -> Unit) {
-    val builder = ValidationNodeBuilder<C, T>()
-    init(builder)
-    run(RequiredValidation(builder.build()))
+fun <C, T : Any, E> ValidationBuilder<C, T?, E>.required(hint: HintBuilder<C, T?, E>, init: ValidationBuilder<C, T, E>.() -> Unit): ConstraintBuilder<C, T?, E> {
+    val builder = ValidationNodeBuilder<C, T, E>(requiredError).also(init)
+    val requiredValidationBuilder = RequiredValidationBuilder(hint, builder, ::identity, "")
+    run(requiredValidationBuilder.build())
+    return requiredValidationBuilder.requiredConstraintBuilder
 }
 
 @JvmName("onEachIterable")
-fun <C, S, T : Iterable<S>> ValidationBuilder<C, T>.onEach(init: ValidationBuilder<C, S>.() -> Unit) {
-    val builder = ValidationNodeBuilder<C, S>()
+fun <C, S, T : Iterable<S>, E> ValidationBuilder<C, T, E>.onEach(init: ValidationBuilder<C, S, E>.() -> Unit) {
+    val builder = ValidationNodeBuilder<C, S, E>(requiredError)
     init(builder)
     @Suppress("UNCHECKED_CAST")
-    run(IterableValidation(builder.build()) as Validation<C, T>)
+    run(IterableValidation(builder.build()) as Validation<C, T, E>)
 }
 
 @JvmName("onEachArray")
-fun <C, T> ValidationBuilder<C, Array<T>>.onEach(init: ValidationBuilder<C, T>.() -> Unit) {
-    val builder = ValidationNodeBuilder<C, T>()
+fun <C, T, E> ValidationBuilder<C, Array<T>, E>.onEach(init: ValidationBuilder<C, T, E>.() -> Unit) {
+    val builder = ValidationNodeBuilder<C, T, E>(requiredError)
     init(builder)
     @Suppress("UNCHECKED_CAST")
-    run(ArrayValidation(builder.build()) as Validation<C, Array<T>>)
+    run(ArrayValidation(builder.build()) as Validation<C, Array<T>, E>)
 }
 
 @JvmName("onEachMap")
-fun <C, K, V, T : Map<K, V>> ValidationBuilder<C, T>.onEach(init: ValidationBuilder<C, Map.Entry<K, V>>.() -> Unit) {
-    val builder = ValidationNodeBuilder<C, Map.Entry<K, V>>()
+fun <C, K, V, T : Map<K, V>, E> ValidationBuilder<C, T, E>.onEach(init: ValidationBuilder<C, Map.Entry<K, V>, E>.() -> Unit) {
+    val builder = ValidationNodeBuilder<C, Map.Entry<K, V>, E>(requiredError)
     init(builder)
     @Suppress("UNCHECKED_CAST")
-    run(MapValidation(builder.build()) as Validation<C, T>)
+    run(MapValidation(builder.build()) as Validation<C, T, E>)
+}
+
+typealias HintArguments = List<Any>
+typealias HintBuilder<C, T, E> = C.(T, HintArguments) -> E
+
+fun <C, T> StringHintBuilder(template: String): HintBuilder<C, T, String> = { value, args ->
+    args
+        .map(Any::toString)
+        .foldIndexed(template.replace("{value}", value.toString())) { index, acc, arg ->
+            acc.replace("{$index}", arg)
+        }
 }

--- a/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
@@ -62,7 +62,7 @@ fun <C, T : Any, E> ValidationBuilder<C, T?, E>.ifPresent(init: ValidationBuilde
 
 fun <C, T : Any, E> ValidationBuilder<C, T?, E>.required(hint: HintBuilder<C, T?, E>, init: ValidationBuilder<C, T, E>.() -> Unit): ConstraintBuilder<C, T?, E> {
     val builder = ValidationNodeBuilder<C, T, E>(requiredError).also(init)
-    val requiredValidationBuilder = RequiredValidationBuilder(hint, builder, ::identity, "")
+    val requiredValidationBuilder = RequiredValidationBuilder(hint, builder)
     run(requiredValidationBuilder.build())
     return requiredValidationBuilder.requiredConstraintBuilder
 }
@@ -79,8 +79,7 @@ fun <C, S, T : Iterable<S>, E> ValidationBuilder<C, T, E>.onEach(init: Validatio
 fun <C, T, E> ValidationBuilder<C, Array<T>, E>.onEach(init: ValidationBuilder<C, T, E>.() -> Unit) {
     val builder = ValidationNodeBuilder<C, T, E>(requiredError)
     init(builder)
-    @Suppress("UNCHECKED_CAST")
-    run(ArrayValidation(builder.build()) as Validation<C, Array<T>, E>)
+    run(ArrayValidation(builder.build()))
 }
 
 @JvmName("onEachMap")
@@ -94,7 +93,7 @@ fun <C, K, V, T : Map<K, V>, E> ValidationBuilder<C, T, E>.onEach(init: Validati
 typealias HintArguments = List<Any>
 typealias HintBuilder<C, T, E> = C.(T, HintArguments) -> E
 
-fun <C, T> StringHintBuilder(template: String): HintBuilder<C, T, String> = { value, args ->
+fun <C, T> stringHintBuilder(template: String): HintBuilder<C, T, String> = { value, args ->
     args
         .map(Any::toString)
         .foldIndexed(template.replace("{value}", value.toString())) { index, acc, arg ->

--- a/src/commonMain/kotlin/io/konform/validation/internal/Builder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/internal/Builder.kt
@@ -41,7 +41,7 @@ internal class ValidationNodeBuilder<C, T, E>: ValidationBuilder<C, T, E>() {
         RequiredHintBuilder(hint, init)
 
     override fun <C, R> with(init: ValidationBuilder<C, R, String>.() -> Unit): HintedRequiredBuilder<C, R, String> =
-        RequiredHintBuilder(stringHintBuilder("is required"), init)
+        RequiredHintBuilder(stringHint("is required"), init)
 
     override fun <S> run(validation: Validation<S, T, E>, map: (C) -> S) =
         add(PrebuildValidationBuilder(validation, map))

--- a/src/commonMain/kotlin/io/konform/validation/internal/Builder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/internal/Builder.kt
@@ -1,123 +1,139 @@
 package io.konform.validation.internal
 
-import io.konform.validation.ConstraintBuilder
-import io.konform.validation.Validation
-import io.konform.validation.ValidationBuilder
+import io.konform.validation.*
 import kotlin.collections.Map.Entry
 import kotlin.reflect.KFunction1
 import kotlin.reflect.KProperty1
 
-internal class ValidationNodeBuilder<C, T> : ValidationBuilder<C, T>() {
-    private val subBuilders = mutableListOf<ComposableBuilder<C, T>>()
+internal class ValidationNodeBuilder<C, T, E>(
+    override val requiredError: E,
+) : ValidationBuilder<C, T, E>() {
+    private val subBuilders = mutableListOf<ComposableBuilder<C, T, E>>()
 
-    override fun build(): Validation<C, T> =
+    override fun build(): Validation<C, T, E> =
         ValidationNode(subBuilders.map { it.build() })
 
-    override fun addConstraint(hint: String, vararg values: String, test: (C, T) -> Boolean): ConstraintBuilder =
+    override fun addConstraint(hint: HintBuilder<C, T, E>, vararg values: Any, test: (C, T) -> Boolean): ConstraintBuilder<C, T, E> =
         ConstraintValidationBuilder(hint, values.toList(), test).also { add(it) }
 
-    override fun <R> KProperty1<T, R>.invoke(init: ValidationBuilder<C, R>.() -> Unit) =
+    override fun <R> KProperty1<T, R>.invoke(init: ValidationBuilder<C, R, E>.() -> Unit) =
         add(MappedValidationBuilder(createBuilder(init), this.name,this))
 
-    override fun <R> KFunction1<T, R>.invoke(init: ValidationBuilder<C, R>.() -> Unit) =
+    override fun <R> KFunction1<T, R>.invoke(init: ValidationBuilder<C, R, E>.() -> Unit) =
         add(MappedValidationBuilder(createBuilder(init), this.name,this))
 
-    override fun <R> onEachIterable(name: String, mapFn: (T) -> Iterable<R>, init: ValidationBuilder<C, R>.() -> Unit) =
+    override fun <R> onEachIterable(name: String, mapFn: (T) -> Iterable<R>, init: ValidationBuilder<C, R, E>.() -> Unit) =
         add(IterableValidationBuilder(createBuilder(init), mapFn, name))
 
-    override fun <R> onEachArray(name: String, mapFn: (T) -> Array<R>, init: ValidationBuilder<C, R>.() -> Unit) =
+    override fun <R> onEachArray(name: String, mapFn: (T) -> Array<R>, init: ValidationBuilder<C, R, E>.() -> Unit) =
         add(ArrayValidationBuilder(createBuilder(init), mapFn, name))
 
-    override fun <K, V> onEachMap(name: String, mapFn: (T) -> Map<K, V>, init: ValidationBuilder<C, Entry<K, V>>.() -> Unit) =
+    override fun <K, V> onEachMap(name: String, mapFn: (T) -> Map<K, V>, init: ValidationBuilder<C, Entry<K, V>, E>.() -> Unit) =
         add(MapValidationBuilder(createBuilder(init), mapFn, name))
 
-    override fun <R : Any> ifPresent(name: String, mapFn: (T) -> R?, init: ValidationBuilder<C, R>.() -> Unit) =
+    override fun <R : Any> ifPresent(name: String, mapFn: (T) -> R?, init: ValidationBuilder<C, R, E>.() -> Unit) =
         add(OptionalValidationBuilder(createBuilder(init),mapFn, name))
 
-    override fun <R : Any> required(name: String, mapFn: (T) -> R?, init: ValidationBuilder<C, R>.() -> Unit) =
-        add(RequiredValidationBuilder(createBuilder(init), mapFn, name))
+    override fun <R : Any> required(name: String, hint: HintBuilder<C, R?, E>, mapFn: (T) -> R?, init: ValidationBuilder<C, R, E>.() -> Unit): ConstraintBuilder<C, R?, E> =
+        RequiredValidationBuilder(hint, createBuilder(init), mapFn, name)
+            .also { add(it) }
+            .requiredConstraintBuilder
 
-    override fun <S> run(validation: Validation<S, T>, map: (C) -> S) =
+    override fun <S> run(validation: Validation<S, T, E>, map: (C) -> S) =
         add(PrebuildValidationBuilder(validation, map))
 
-    override val <R> KProperty1<T, R>.has: ValidationBuilder<C, R>
-        get() = ValidationNodeBuilder<C, R>()
+    override val <R> KProperty1<T, R>.has: ValidationBuilder<C, R, E>
+        get() = ValidationNodeBuilder<C, R, E>(requiredError)
             .also { add(MappedValidationBuilder(it, this.name,this)) }
 
-    private fun <D, S> createBuilder(init: ValidationBuilder<D, S>.() -> Unit) =
-        ValidationNodeBuilder<D, S>().also(init)
+    private fun <D, S> createBuilder(init: ValidationBuilder<D, S, E>.() -> Unit) =
+        ValidationNodeBuilder<D, S, E>(requiredError).also(init)
 
-    private fun add(builder: ComposableBuilder<C, T>) {
+    private fun add(builder: ComposableBuilder<C, T, E>) {
         subBuilders.add(builder)
     }
 }
 
-internal interface ComposableBuilder<C, T> {
-    fun build(): Validation<C, T>
+internal interface ComposableBuilder<C, T, E> {
+    fun build(): Validation<C, T, E>
 }
 
-internal class MappedValidationBuilder<C, T, V>(
-    private val subBuilder: ValidationBuilder<C, V>,
+internal class MappedValidationBuilder<C, T, V, E>(
+    private val subBuilder: ValidationBuilder<C, V, E>,
     private val name: String,
     private val mapFn: (T) -> V,
-) : ComposableBuilder<C, T> {
-    override fun build(): Validation<C, T> = MappedValidation(subBuilder.build(), name, mapFn)
+) : ComposableBuilder<C, T, E> {
+    override fun build(): Validation<C, T, E> = MappedValidation(subBuilder.build(), name, mapFn)
 }
 
-internal class IterableValidationBuilder<C, T, V>(
-    private val subBuilder: ValidationBuilder<C, V>,
+internal class IterableValidationBuilder<C, T, V, E>(
+    private val subBuilder: ValidationBuilder<C, V, E>,
     private val mapFn: (T) -> Iterable<V>,
     private val name: String,
-) : ComposableBuilder<C, T> {
-    override fun build(): Validation<C, T> = MappedValidation(IterableValidation(subBuilder.build()), name, mapFn)
+) : ComposableBuilder<C, T, E> {
+    override fun build(): Validation<C, T, E> = MappedValidation(IterableValidation(subBuilder.build()), name, mapFn)
 }
 
-internal class ArrayValidationBuilder<C, T, V>(
-    private val subBuilder: ValidationBuilder<C, V>,
+internal class ArrayValidationBuilder<C, T, V, E>(
+    private val subBuilder: ValidationBuilder<C, V, E>,
     private val mapFn: (T) -> Array<V>,
     private val name: String,
-) : ComposableBuilder<C, T> {
-    override fun build(): Validation<C, T> = MappedValidation(ArrayValidation(subBuilder.build()), name, mapFn)
+) : ComposableBuilder<C, T, E> {
+    override fun build(): Validation<C, T, E> = MappedValidation(ArrayValidation(subBuilder.build()), name, mapFn)
 }
 
-internal class MapValidationBuilder<C, T, K, V>(
-    private val subBuilder: ValidationBuilder<C, Entry<K, V>>,
+internal class MapValidationBuilder<C, T, K, V, E>(
+    private val subBuilder: ValidationBuilder<C, Entry<K, V>, E>,
     private val mapFn: (T) -> Map<K, V>,
     private val name: String,
-) : ComposableBuilder<C, T> {
-    override fun build(): Validation<C, T> = MappedValidation(MapValidation(subBuilder.build()), name, mapFn)
+) : ComposableBuilder<C, T, E> {
+    override fun build(): Validation<C, T, E> = MappedValidation(MapValidation(subBuilder.build()), name, mapFn)
 }
 
-internal class OptionalValidationBuilder<C, T, V: Any>(
-    private val subBuilder: ValidationBuilder<C, V>,
+internal class OptionalValidationBuilder<C, T, V: Any, E>(
+    private val subBuilder: ValidationBuilder<C, V, E>,
     private val mapFn: (T) -> V?,
     private val name: String,
-) : ComposableBuilder<C, T> {
-    override fun build(): Validation<C, T> = MappedValidation(OptionalValidation(subBuilder.build()), name, mapFn)
+) : ComposableBuilder<C, T, E> {
+    override fun build(): Validation<C, T, E> = MappedValidation(OptionalValidation(subBuilder.build()), name, mapFn)
 }
 
-internal class RequiredValidationBuilder<C, T, V: Any>(
-    private val subBuilder: ValidationBuilder<C, V>,
+internal class RequiredValidationBuilder<C, T, V: Any, E>(
+    hint: HintBuilder<C, V?, E>,
+    private val subBuilder: ValidationBuilder<C, V, E>,
     private val mapFn: (T) -> V?,
     private val name: String,
-) : ComposableBuilder<C, T> {
-    override fun build(): Validation<C, T> = MappedValidation(RequiredValidation(subBuilder.build()), name, mapFn)
+) : ComposableBuilder<C, T, E> {
+    val requiredConstraintBuilder: ConstraintValidationBuilder<C, V?, E> =
+        ConstraintValidationBuilder(hint, emptyList()) { _, value ->
+            value != null
+        }
+
+    override fun build(): Validation<C, T, E> =
+        MappedValidation(
+            RequiredValidation(
+                requiredConstraintBuilder.build(),
+                subBuilder.build(),
+            ),
+            name,
+            mapFn,
+        )
 }
 
-internal class PrebuildValidationBuilder<C, T, S>(
-    private val validation: Validation<S, T>,
+internal class PrebuildValidationBuilder<C, T, S, E>(
+    private val validation: Validation<S, T, E>,
     private val mapFn: (C) -> S,
-) : ComposableBuilder<C, T> {
-    override fun build(): Validation<C, T> = MappedContextValidation(validation, mapFn)
+) : ComposableBuilder<C, T, E> {
+    override fun build(): Validation<C, T, E> = MappedContextValidation(validation, mapFn)
 }
 
-internal class ConstraintValidationBuilder<C, T>(
-    private var hint: String,
-    private val templateValues: List<String>,
+internal class ConstraintValidationBuilder<C, T, E>(
+    private var hint: HintBuilder<C, T, E>,
+    private val arguments: HintArguments,
     private val test: (C, T) -> Boolean,
-) : ComposableBuilder<C, T>, ConstraintBuilder {
-    override fun build(): Validation<C, T> = ConstraintValidation(hint, templateValues, test)
-    override infix fun hint(hint: String): ConstraintValidationBuilder<C, T> {
+) : ComposableBuilder<C, T, E>, ConstraintBuilder<C, T, E> {
+    override fun build(): Validation<C, T, E> = ConstraintValidation(hint, arguments, test)
+    override infix fun hint(hint: HintBuilder<C, T, E>): ConstraintValidationBuilder<C, T, E> {
         this.hint = hint
         return this
     }

--- a/src/commonMain/kotlin/io/konform/validation/internal/Builder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/internal/Builder.kt
@@ -141,6 +141,10 @@ internal class ValidationBuilderImpl<C, T> : ValidationBuilder<C, T>() {
         prebuiltValidations.add(validation)
     }
 
+    override fun <S> run(validation: Validation<S, T>, map: (C) -> S) {
+        prebuiltValidations.add(MappedValidation(validation, map))
+    }
+
     override fun build(): Validation<C, T> {
         val nestedValidations = subValidations.map { (key, builder) ->
             key.build(builder)

--- a/src/commonMain/kotlin/io/konform/validation/internal/Builder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/internal/Builder.kt
@@ -1,154 +1,124 @@
 package io.konform.validation.internal
 
-import io.konform.validation.Constraint
+import io.konform.validation.ConstraintBuilder
 import io.konform.validation.Validation
 import io.konform.validation.ValidationBuilder
-import io.konform.validation.internal.ValidationBuilderImpl.Companion.PropModifier.NonNull
-import io.konform.validation.internal.ValidationBuilderImpl.Companion.PropModifier.Optional
-import io.konform.validation.internal.ValidationBuilderImpl.Companion.PropModifier.OptionalRequired
 import kotlin.collections.Map.Entry
+import kotlin.reflect.KFunction1
 import kotlin.reflect.KProperty1
 
-internal class ValidationBuilderImpl<C, T> : ValidationBuilder<C, T>() {
-    companion object {
-        private enum class PropModifier {
-            NonNull, Optional, OptionalRequired
-        }
+internal class ValidationNodeBuilder<C, T> : ValidationBuilder<C, T>() {
+    private val subBuilders = mutableListOf<ComposableBuilder<C, T>>()
 
-        private abstract class PropKey<C, T> {
-            abstract fun build(builder: ValidationBuilderImpl<C, *>): Validation<C, T>
-        }
+    override fun build(): Validation<C, T> =
+        ValidationNode(subBuilders.map { it.build() })
 
-        private data class SingleValuePropKey<C, T, R>(
-            val property: KProperty1<T, R>,
-            val modifier: PropModifier
-        ) : PropKey<C, T>() {
-            override fun build(builder: ValidationBuilderImpl<C, *>): Validation<C, T> {
-                @Suppress("UNCHECKED_CAST")
-                val validations = (builder as ValidationBuilderImpl<C, R>).build()
-                return when (modifier) {
-                    NonNull -> NonNullPropertyValidation(property, validations)
-                    Optional -> OptionalPropertyValidation(property, validations)
-                    OptionalRequired -> RequiredPropertyValidation(property, validations)
-                }
-            }
-        }
+    override fun addConstraint(hint: String, vararg values: String, test: (C, T) -> Boolean): ConstraintBuilder =
+        ConstraintValidationBuilder(hint, values.toList(), test).also { add(it) }
 
-        private data class IterablePropKey<C, T, R>(
-            val property: KProperty1<T, Iterable<R>>,
-            val modifier: PropModifier
-        ) : PropKey<C, T>() {
-            override fun build(builder: ValidationBuilderImpl<C, *>): Validation<C, T> {
-                @Suppress("UNCHECKED_CAST")
-                val validations = (builder as ValidationBuilderImpl<C, R>).build()
-                @Suppress("UNCHECKED_CAST")
-                return when (modifier) {
-                    NonNull -> NonNullPropertyValidation(property, IterableValidation(validations))
-                    Optional -> OptionalPropertyValidation(property, IterableValidation(validations))
-                    OptionalRequired -> RequiredPropertyValidation(property, IterableValidation(validations))
-                }
-            }
-        }
+    override fun <R> KProperty1<T, R>.invoke(init: ValidationBuilder<C, R>.() -> Unit) =
+        add(MappedValidationBuilder(createBuilder(init), this.name,this))
 
-        private data class ArrayPropKey<C, T, R>(
-            val property: KProperty1<T, Array<R>>,
-            val modifier: PropModifier
-        ) : PropKey<C, T>() {
-            override fun build(builder: ValidationBuilderImpl<C, *>): Validation<C, T> {
-                @Suppress("UNCHECKED_CAST")
-                val validations = (builder as ValidationBuilderImpl<C, R>).build()
-                @Suppress("UNCHECKED_CAST")
-                return when (modifier) {
-                    NonNull -> NonNullPropertyValidation(property, ArrayValidation(validations))
-                    Optional -> OptionalPropertyValidation(property, ArrayValidation(validations))
-                    OptionalRequired -> RequiredPropertyValidation(property, ArrayValidation(validations))
-                }
-            }
-        }
+    override fun <R> KFunction1<T, R>.invoke(init: ValidationBuilder<C, R>.() -> Unit) =
+        add(MappedValidationBuilder(createBuilder(init), this.name,this))
 
-        private data class MapPropKey<C, T, K, V>(
-            val property: KProperty1<T, Map<K, V>>,
-            val modifier: PropModifier
-        ) : PropKey<C, T>() {
-            override fun build(builder: ValidationBuilderImpl<C, *>): Validation<C, T> {
-                @Suppress("UNCHECKED_CAST")
-                val validations = (builder as ValidationBuilderImpl<C, Entry<K, V>>).build()
-                return when (modifier) {
-                    NonNull -> NonNullPropertyValidation(property, MapValidation(validations))
-                    Optional -> OptionalPropertyValidation(property, MapValidation(validations))
-                    OptionalRequired -> RequiredPropertyValidation(property, MapValidation(validations))
-                }
-            }
-        }
-    }
+    override fun <R> onEachIterable(name: String, mapFn: (T) -> Iterable<R>, init: ValidationBuilder<C, R>.() -> Unit) =
+        add(IterableValidationBuilder(createBuilder(init), mapFn, name))
 
-    private val constraints = mutableListOf<Constraint<C, T>>()
-    private val subValidations = mutableMapOf<PropKey<C, T>, ValidationBuilderImpl<C, *>>()
-    private val prebuiltValidations = mutableListOf<Validation<C, T>>()
+    override fun <R> onEachArray(name: String, mapFn: (T) -> Array<R>, init: ValidationBuilder<C, R>.() -> Unit) =
+        add(ArrayValidationBuilder(createBuilder(init), mapFn, name))
 
-    override fun Constraint<C, T>.hint(hint: String): Constraint<C, T> =
-        Constraint(hint, this.templateValues, this.test).also { constraints.remove(this); constraints.add(it) }
+    override fun <K, V> onEachMap(name: String, mapFn: (T) -> Map<K, V>, init: ValidationBuilder<C, Entry<K, V>>.() -> Unit) =
+        add(MapValidationBuilder(createBuilder(init), mapFn, name))
 
-    override fun addConstraint(errorMessage: String, vararg templateValues: String, test: (C, T) -> Boolean): Constraint<C, T> {
-        return Constraint(errorMessage, templateValues.toList(), test).also { constraints.add(it) }
-    }
+    override fun <R : Any> ifPresent(name: String, mapFn: (T) -> R?, init: ValidationBuilder<C, R>.() -> Unit) =
+        add(OptionalValidationBuilder(createBuilder(init),mapFn, name))
 
-    private fun <R> KProperty1<T, R?>.getOrCreateBuilder(modifier: PropModifier): ValidationBuilder<C, R> {
-        val key = SingleValuePropKey<C, T, R?>(this, modifier)
-        @Suppress("UNCHECKED_CAST")
-        return (subValidations.getOrPut(key, { ValidationBuilderImpl<C, R>() }) as ValidationBuilder<C, R>)
-    }
+    override fun <R : Any> required(name: String, mapFn: (T) -> R?, init: ValidationBuilder<C, R>.() -> Unit) =
+        add(RequiredValidationBuilder(createBuilder(init), mapFn, name))
 
-    private fun <R> KProperty1<T, Iterable<R>>.getOrCreateIterablePropertyBuilder(modifier: PropModifier): ValidationBuilder<C, R> {
-        val key = IterablePropKey<C, T, R>(this, modifier)
-        @Suppress("UNCHECKED_CAST")
-        return (subValidations.getOrPut(key, { ValidationBuilderImpl<C, R>() }) as ValidationBuilder<C, R>)
-    }
-
-    private fun <R> PropKey<C, T>.getOrCreateBuilder(): ValidationBuilder<C, R> {
-        @Suppress("UNCHECKED_CAST")
-        return (subValidations.getOrPut(this, { ValidationBuilderImpl<C, R>() }) as ValidationBuilder<C, R>)
-    }
-
-    override fun <R> KProperty1<T, R>.invoke(init: ValidationBuilder<C, R>.() -> Unit) {
-        getOrCreateBuilder(NonNull).also(init)
-    }
-
-    override fun <R> onEachIterable(prop: KProperty1<T, Iterable<R>>, init: ValidationBuilder<C, R>.() -> Unit) {
-        prop.getOrCreateIterablePropertyBuilder(NonNull).also(init)
-    }
-
-    override fun <R> onEachArray(prop: KProperty1<T, Array<R>>, init: ValidationBuilder<C, R>.() -> Unit) {
-        ArrayPropKey<C, T, R>(prop, NonNull).getOrCreateBuilder<R>().also(init)
-    }
-
-    override fun <K, V> onEachMap(prop: KProperty1<T, Map<K, V>>, init: ValidationBuilder<C, Entry<K, V>>.() -> Unit) {
-        MapPropKey<C, T, K, V>(prop, NonNull).getOrCreateBuilder<Entry<K, V>>().also(init)
-    }
-
-    override fun <R> KProperty1<T, R?>.ifPresent(init: ValidationBuilder<C, R>.() -> Unit) {
-        getOrCreateBuilder(Optional).also(init)
-    }
-
-    override fun <R> KProperty1<T, R?>.required(init: ValidationBuilder<C, R>.() -> Unit) {
-        getOrCreateBuilder(OptionalRequired).also(init)
-    }
+    override fun <S> run(validation: Validation<S, T>, map: (C) -> S) =
+        add(PrebuildValidationBuilder(validation, map))
 
     override val <R> KProperty1<T, R>.has: ValidationBuilder<C, R>
-        get() = getOrCreateBuilder(NonNull)
+        get() = ValidationNodeBuilder<C, R>()
+            .also { add(MappedValidationBuilder(it, this.name,this)) }
 
-    override fun run(validation: Validation<C, T>) {
-        prebuiltValidations.add(validation)
+    private fun <D, S> createBuilder(init: ValidationBuilder<D, S>.() -> Unit) =
+        ValidationNodeBuilder<D, S>().also(init)
+
+    private fun add(builder: ComposableBuilder<C, T>) {
+        subBuilders.add(builder)
     }
+}
 
-    override fun <S> run(validation: Validation<S, T>, map: (C) -> S) {
-        prebuiltValidations.add(MappedValidation(validation, map))
-    }
+internal interface ComposableBuilder<C, T> {
+    fun build(): Validation<C, T>
+}
 
-    override fun build(): Validation<C, T> {
-        val nestedValidations = subValidations.map { (key, builder) ->
-            key.build(builder)
-        }
-        return ValidationNode(constraints, nestedValidations + prebuiltValidations)
+internal class MappedValidationBuilder<C, T, V>(
+    private val subBuilder: ValidationBuilder<C, V>,
+    private val name: String,
+    private val mapFn: (T) -> V,
+) : ComposableBuilder<C, T> {
+    override fun build(): Validation<C, T> = MappedValidation(subBuilder.build(), name, mapFn)
+}
+
+internal class IterableValidationBuilder<C, T, V>(
+    private val subBuilder: ValidationBuilder<C, V>,
+    private val mapFn: (T) -> Iterable<V>,
+    private val name: String,
+) : ComposableBuilder<C, T> {
+    override fun build(): Validation<C, T> = MappedValidation(IterableValidation(subBuilder.build()), name, mapFn)
+}
+
+internal class ArrayValidationBuilder<C, T, V>(
+    private val subBuilder: ValidationBuilder<C, V>,
+    private val mapFn: (T) -> Array<V>,
+    private val name: String,
+) : ComposableBuilder<C, T> {
+    override fun build(): Validation<C, T> = MappedValidation(ArrayValidation(subBuilder.build()), name, mapFn)
+}
+
+internal class MapValidationBuilder<C, T, K, V>(
+    private val subBuilder: ValidationBuilder<C, Entry<K, V>>,
+    private val mapFn: (T) -> Map<K, V>,
+    private val name: String,
+) : ComposableBuilder<C, T> {
+    override fun build(): Validation<C, T> = MappedValidation(MapValidation(subBuilder.build()), name, mapFn)
+}
+
+internal class OptionalValidationBuilder<C, T, V: Any>(
+    private val subBuilder: ValidationBuilder<C, V>,
+    private val mapFn: (T) -> V?,
+    private val name: String,
+) : ComposableBuilder<C, T> {
+    override fun build(): Validation<C, T> = MappedValidation(OptionalValidation(subBuilder.build()), name, mapFn)
+}
+
+internal class RequiredValidationBuilder<C, T, V: Any>(
+    private val subBuilder: ValidationBuilder<C, V>,
+    private val mapFn: (T) -> V?,
+    private val name: String,
+) : ComposableBuilder<C, T> {
+    override fun build(): Validation<C, T> = MappedValidation(RequiredValidation(subBuilder.build()), name, mapFn)
+}
+
+internal class PrebuildValidationBuilder<C, T, S>(
+    private val validation: Validation<S, T>,
+    private val mapFn: (C) -> S,
+) : ComposableBuilder<C, T> {
+    override fun build(): Validation<C, T> = MappedContextValidation(validation, mapFn)
+}
+
+internal class ConstraintValidationBuilder<C, T>(
+    private var hint: String,
+    private val templateValues: List<String>,
+    private val test: (C, T) -> Boolean,
+) : ComposableBuilder<C, T>, ConstraintBuilder {
+    override fun build(): Validation<C, T> = ConstraintValidation(hint, templateValues, test)
+    override infix fun hint(hint: String): ConstraintValidationBuilder<C, T> {
+        this.hint = hint
+        return this
     }
 }

--- a/src/commonMain/kotlin/io/konform/validation/internal/Builder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/internal/Builder.kt
@@ -9,23 +9,23 @@ import io.konform.validation.internal.ValidationBuilderImpl.Companion.PropModifi
 import kotlin.collections.Map.Entry
 import kotlin.reflect.KProperty1
 
-internal class ValidationBuilderImpl<T> : ValidationBuilder<T>() {
+internal class ValidationBuilderImpl<C, T> : ValidationBuilder<C, T>() {
     companion object {
         private enum class PropModifier {
             NonNull, Optional, OptionalRequired
         }
 
-        private abstract class PropKey<T> {
-            abstract fun build(builder: ValidationBuilderImpl<*>): Validation<T>
+        private abstract class PropKey<C, T> {
+            abstract fun build(builder: ValidationBuilderImpl<C, *>): Validation<C, T>
         }
 
-        private data class SingleValuePropKey<T, R>(
+        private data class SingleValuePropKey<C, T, R>(
             val property: KProperty1<T, R>,
             val modifier: PropModifier
-        ) : PropKey<T>() {
-            override fun build(builder: ValidationBuilderImpl<*>): Validation<T> {
+        ) : PropKey<C, T>() {
+            override fun build(builder: ValidationBuilderImpl<C, *>): Validation<C, T> {
                 @Suppress("UNCHECKED_CAST")
-                val validations = (builder as ValidationBuilderImpl<R>).build()
+                val validations = (builder as ValidationBuilderImpl<C, R>).build()
                 return when (modifier) {
                     NonNull -> NonNullPropertyValidation(property, validations)
                     Optional -> OptionalPropertyValidation(property, validations)
@@ -34,13 +34,13 @@ internal class ValidationBuilderImpl<T> : ValidationBuilder<T>() {
             }
         }
 
-        private data class IterablePropKey<T, R>(
+        private data class IterablePropKey<C, T, R>(
             val property: KProperty1<T, Iterable<R>>,
             val modifier: PropModifier
-        ) : PropKey<T>() {
-            override fun build(builder: ValidationBuilderImpl<*>): Validation<T> {
+        ) : PropKey<C, T>() {
+            override fun build(builder: ValidationBuilderImpl<C, *>): Validation<C, T> {
                 @Suppress("UNCHECKED_CAST")
-                val validations = (builder as ValidationBuilderImpl<R>).build()
+                val validations = (builder as ValidationBuilderImpl<C, R>).build()
                 @Suppress("UNCHECKED_CAST")
                 return when (modifier) {
                     NonNull -> NonNullPropertyValidation(property, IterableValidation(validations))
@@ -50,13 +50,13 @@ internal class ValidationBuilderImpl<T> : ValidationBuilder<T>() {
             }
         }
 
-        private data class ArrayPropKey<T, R>(
+        private data class ArrayPropKey<C, T, R>(
             val property: KProperty1<T, Array<R>>,
             val modifier: PropModifier
-        ) : PropKey<T>() {
-            override fun build(builder: ValidationBuilderImpl<*>): Validation<T> {
+        ) : PropKey<C, T>() {
+            override fun build(builder: ValidationBuilderImpl<C, *>): Validation<C, T> {
                 @Suppress("UNCHECKED_CAST")
-                val validations = (builder as ValidationBuilderImpl<R>).build()
+                val validations = (builder as ValidationBuilderImpl<C, R>).build()
                 @Suppress("UNCHECKED_CAST")
                 return when (modifier) {
                     NonNull -> NonNullPropertyValidation(property, ArrayValidation(validations))
@@ -66,13 +66,13 @@ internal class ValidationBuilderImpl<T> : ValidationBuilder<T>() {
             }
         }
 
-        private data class MapPropKey<T, K, V>(
+        private data class MapPropKey<C, T, K, V>(
             val property: KProperty1<T, Map<K, V>>,
             val modifier: PropModifier
-        ) : PropKey<T>() {
-            override fun build(builder: ValidationBuilderImpl<*>): Validation<T> {
+        ) : PropKey<C, T>() {
+            override fun build(builder: ValidationBuilderImpl<C, *>): Validation<C, T> {
                 @Suppress("UNCHECKED_CAST")
-                val validations = (builder as ValidationBuilderImpl<Map.Entry<K, V>>).build()
+                val validations = (builder as ValidationBuilderImpl<C, Entry<K, V>>).build()
                 return when (modifier) {
                     NonNull -> NonNullPropertyValidation(property, MapValidation(validations))
                     Optional -> OptionalPropertyValidation(property, MapValidation(validations))
@@ -84,66 +84,66 @@ internal class ValidationBuilderImpl<T> : ValidationBuilder<T>() {
 
     }
 
-    private val constraints = mutableListOf<Constraint<T>>()
-    private val subValidations = mutableMapOf<PropKey<T>, ValidationBuilderImpl<*>>()
-    private val prebuiltValidations = mutableListOf<Validation<T>>()
+    private val constraints = mutableListOf<Constraint<C, T>>()
+    private val subValidations = mutableMapOf<PropKey<C, T>, ValidationBuilderImpl<C, *>>()
+    private val prebuiltValidations = mutableListOf<Validation<C, T>>()
 
-    override fun Constraint<T>.hint(hint: String): Constraint<T> =
+    override fun Constraint<C, T>.hint(hint: String): Constraint<C, T> =
         Constraint(hint, this.templateValues, this.test).also { constraints.remove(this); constraints.add(it) }
 
-    override fun addConstraint(errorMessage: String, vararg templateValues: String, test: (T) -> Boolean): Constraint<T> {
+    override fun addConstraint(errorMessage: String, vararg templateValues: String, test: (C, T) -> Boolean): Constraint<C, T> {
         return Constraint(errorMessage, templateValues.toList(), test).also { constraints.add(it) }
     }
 
-    private fun <R> KProperty1<T, R?>.getOrCreateBuilder(modifier: PropModifier): ValidationBuilder<R> {
-        val key = SingleValuePropKey(this, modifier)
+    private fun <R> KProperty1<T, R?>.getOrCreateBuilder(modifier: PropModifier): ValidationBuilder<C, R> {
+        val key = SingleValuePropKey<C, T, R?>(this, modifier)
         @Suppress("UNCHECKED_CAST")
-        return (subValidations.getOrPut(key, { ValidationBuilderImpl<R>() }) as ValidationBuilder<R>)
+        return (subValidations.getOrPut(key, { ValidationBuilderImpl<C, R>() }) as ValidationBuilder<C, R>)
     }
 
-    private fun <R> KProperty1<T, Iterable<R>>.getOrCreateIterablePropertyBuilder(modifier: PropModifier): ValidationBuilder<R> {
-        val key = IterablePropKey(this, modifier)
+    private fun <R> KProperty1<T, Iterable<R>>.getOrCreateIterablePropertyBuilder(modifier: PropModifier): ValidationBuilder<C, R> {
+        val key = IterablePropKey<C, T, R>(this, modifier)
         @Suppress("UNCHECKED_CAST")
-        return (subValidations.getOrPut(key, { ValidationBuilderImpl<R>() }) as ValidationBuilder<R>)
+        return (subValidations.getOrPut(key, { ValidationBuilderImpl<C, R>() }) as ValidationBuilder<C, R>)
     }
 
-    private fun <R> PropKey<T>.getOrCreateBuilder(): ValidationBuilder<R> {
+    private fun <R> PropKey<C, T>.getOrCreateBuilder(): ValidationBuilder<C, R> {
         @Suppress("UNCHECKED_CAST")
-        return (subValidations.getOrPut(this, { ValidationBuilderImpl<R>() }) as ValidationBuilder<R>)
+        return (subValidations.getOrPut(this, { ValidationBuilderImpl<C, R>() }) as ValidationBuilder<C, R>)
     }
 
-    override fun <R> KProperty1<T, R>.invoke(init: ValidationBuilder<R>.() -> Unit) {
+    override fun <R> KProperty1<T, R>.invoke(init: ValidationBuilder<C, R>.() -> Unit) {
         getOrCreateBuilder(NonNull).also(init)
     }
 
-    override fun <R> onEachIterable(prop: KProperty1<T, Iterable<R>>, init: ValidationBuilder<R>.() -> Unit) {
+    override fun <R> onEachIterable(prop: KProperty1<T, Iterable<R>>, init: ValidationBuilder<C, R>.() -> Unit) {
         prop.getOrCreateIterablePropertyBuilder(NonNull).also(init)
     }
 
-    override fun <R> onEachArray(prop: KProperty1<T, Array<R>>, init: ValidationBuilder<R>.() -> Unit) {
-        ArrayPropKey(prop, NonNull).getOrCreateBuilder<R>().also(init)
+    override fun <R> onEachArray(prop: KProperty1<T, Array<R>>, init: ValidationBuilder<C, R>.() -> Unit) {
+        ArrayPropKey<C, T, R>(prop, NonNull).getOrCreateBuilder<R>().also(init)
     }
 
-    override fun <K, V> onEachMap(prop: KProperty1<T, Map<K, V>>, init: ValidationBuilder<Entry<K, V>>.() -> Unit) {
-        MapPropKey(prop, NonNull).getOrCreateBuilder<Map.Entry<K, V>>().also(init)
+    override fun <K, V> onEachMap(prop: KProperty1<T, Map<K, V>>, init: ValidationBuilder<C, Entry<K, V>>.() -> Unit) {
+        MapPropKey<C, T, K, V>(prop, NonNull).getOrCreateBuilder<Entry<K, V>>().also(init)
     }
 
-    override fun <R> KProperty1<T, R?>.ifPresent(init: ValidationBuilder<R>.() -> Unit) {
+    override fun <R> KProperty1<T, R?>.ifPresent(init: ValidationBuilder<C, R>.() -> Unit) {
         getOrCreateBuilder(Optional).also(init)
     }
 
-    override fun <R> KProperty1<T, R?>.required(init: ValidationBuilder<R>.() -> Unit) {
+    override fun <R> KProperty1<T, R?>.required(init: ValidationBuilder<C, R>.() -> Unit) {
         getOrCreateBuilder(OptionalRequired).also(init)
     }
 
-    override val <R> KProperty1<T, R>.has: ValidationBuilder<R>
+    override val <R> KProperty1<T, R>.has: ValidationBuilder<C, R>
         get() = getOrCreateBuilder(NonNull)
 
-    override fun run(validation: Validation<T>) {
+    override fun run(validation: Validation<C, T>) {
         prebuiltValidations.add(validation)
     }
 
-    override fun build(): Validation<T> {
+    override fun build(): Validation<C, T> {
         val nestedValidations = subValidations.map { (key, builder) ->
             key.build(builder)
         }

--- a/src/commonMain/kotlin/io/konform/validation/internal/Builder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/internal/Builder.kt
@@ -80,8 +80,6 @@ internal class ValidationBuilderImpl<C, T> : ValidationBuilder<C, T>() {
                 }
             }
         }
-
-
     }
 
     private val constraints = mutableListOf<Constraint<C, T>>()

--- a/src/commonMain/kotlin/io/konform/validation/internal/Validation.kt
+++ b/src/commonMain/kotlin/io/konform/validation/internal/Validation.kt
@@ -7,6 +7,14 @@ import io.konform.validation.Validation
 import io.konform.validation.ValidationResult
 import kotlin.reflect.KProperty1
 
+internal class MappedValidation<C, S, T>(
+    private val validation: Validation<S, T>,
+    private val map: (C) -> S,
+) : Validation<C, T> {
+    override fun validate(context: C, value: T): ValidationResult<T> =
+        validation(map(context), value)
+}
+
 internal class OptionalValidation<C, T: Any>(
     private val validation: Validation<C, T>
 ) : Validation<C, T?> {

--- a/src/commonMain/kotlin/io/konform/validation/internal/Validation.kt
+++ b/src/commonMain/kotlin/io/konform/validation/internal/Validation.kt
@@ -7,105 +7,102 @@ import io.konform.validation.Validation
 import io.konform.validation.ValidationResult
 import kotlin.reflect.KProperty1
 
-internal class OptionalValidation<T: Any>(
-    private val validation: Validation<T>
-) : Validation<T?> {
-    override fun validate(value: T?): ValidationResult<T?> {
+internal class OptionalValidation<C, T: Any>(
+    private val validation: Validation<C, T>
+) : Validation<C, T?> {
+    override fun validate(context: C, value: T?): ValidationResult<T?> {
         val nonNullValue = value ?: return Valid(value)
-        return validation(nonNullValue)
+        return validation(context, nonNullValue)
     }
 }
 
-internal class RequiredValidation<T: Any>(
-    private val validation: Validation<T>
-) : Validation<T?> {
-    override fun validate(value: T?): ValidationResult<T?> {
+internal class RequiredValidation<C, T: Any>(
+    private val validation: Validation<C, T>
+) : Validation<C, T?> {
+    override fun validate(context: C, value: T?): ValidationResult<T?> {
         val nonNullValue = value
             ?: return Invalid(mapOf("" to listOf("is required")))
-        return validation(nonNullValue)
+        return validation(context, nonNullValue)
     }
 }
 
-internal class NonNullPropertyValidation<T, R>(
+internal class NonNullPropertyValidation<C, T, R>(
     private val property: KProperty1<T, R>,
-    private val validation: Validation<R>
-) : Validation<T> {
-    override fun validate(value: T): ValidationResult<T> {
+    private val validation: Validation<C, R>
+) : Validation<C, T> {
+    override fun validate(context: C, value: T): ValidationResult<T> {
         val propertyValue = property(value)
-        return validation(propertyValue).mapError { ".${property.name}$it" }.map { value }
+        return validation(context, propertyValue).mapError { ".${property.name}$it" }.map { value }
     }
 }
 
-internal class OptionalPropertyValidation<T, R>(
+internal class OptionalPropertyValidation<C, T, R>(
     private val property: KProperty1<T, R?>,
-    private val validation: Validation<R>
-) : Validation<T> {
-    override fun validate(value: T): ValidationResult<T> {
+    private val validation: Validation<C, R>
+) : Validation<C, T> {
+    override fun validate(context: C, value: T): ValidationResult<T> {
         val propertyValue = property(value) ?: return Valid(value)
-        return validation(propertyValue).mapError { ".${property.name}$it" }.map { value }
+        return validation(context, propertyValue).mapError { ".${property.name}$it" }.map { value }
     }
 }
 
-internal class RequiredPropertyValidation<T, R>(
+internal class RequiredPropertyValidation<C, T, R>(
     private val property: KProperty1<T, R?>,
-    private val validation: Validation<R>
-) : Validation<T> {
-    override fun validate(value: T): ValidationResult<T> {
+    private val validation: Validation<C, R>
+) : Validation<C, T> {
+    override fun validate(context: C, value: T): ValidationResult<T> {
         val propertyValue = property(value)
             ?: return Invalid<T>(mapOf(".${property.name}" to listOf("is required")))
-        return validation(propertyValue).mapError { ".${property.name}${it}" }.map { value }
+        return validation(context, propertyValue).mapError { ".${property.name}${it}" }.map { value }
     }
 }
 
-internal class IterableValidation<T>(
-    private val validation: Validation<T>
-) : Validation<Iterable<T>> {
-    override fun validate(value: Iterable<T>): ValidationResult<Iterable<T>> {
+internal class IterableValidation<C, T>(
+    private val validation: Validation<C, T>
+) : Validation<C, Iterable<T>> {
+    override fun validate(context: C, value: Iterable<T>): ValidationResult<Iterable<T>> {
         return value.foldIndexed(Valid(value)) { index, result: ValidationResult<Iterable<T>>, propertyValue ->
-            val propertyValidation = validation(propertyValue).mapError { "[$index]$it" }.map { value }
+            val propertyValidation = validation(context, propertyValue).mapError { "[$index]$it" }.map { value }
             result.combineWith(propertyValidation)
         }
-
     }
 }
 
-internal class ArrayValidation<T>(
-    private val validation: Validation<T>
-) : Validation<Array<T>> {
-    override fun validate(value: Array<T>): ValidationResult<Array<T>> {
+internal class ArrayValidation<C, T>(
+    private val validation: Validation<C, T>
+) : Validation<C, Array<T>> {
+    override fun validate(context: C, value: Array<T>): ValidationResult<Array<T>> {
         return value.foldIndexed(Valid(value)) { index, result: ValidationResult<Array<T>>, propertyValue ->
-            val propertyValidation = validation(propertyValue).mapError { "[$index]$it" }.map { value }
+            val propertyValidation = validation(context, propertyValue).mapError { "[$index]$it" }.map { value }
             result.combineWith(propertyValidation)
         }
-
     }
 }
 
-internal class MapValidation<K, V>(
-    private val validation: Validation<Map.Entry<K, V>>
-) : Validation<Map<K, V>> {
-    override fun validate(value: Map<K, V>): ValidationResult<Map<K, V>> {
+internal class MapValidation<C, K, V>(
+    private val validation: Validation<C, Map.Entry<K, V>>
+) : Validation<C, Map<K, V>> {
+    override fun validate(context: C, value: Map<K, V>): ValidationResult<Map<K, V>> {
         return value.asSequence().fold(Valid(value)) { result: ValidationResult<Map<K, V>>, entry ->
-            val propertyValidation = validation(entry).mapError { ".${entry.key.toString()}${it.removePrefix(".value")}" }.map { value }
+            val propertyValidation = validation(context, entry).mapError { ".${entry.key.toString()}${it.removePrefix(".value")}" }.map { value }
             result.combineWith(propertyValidation)
         }
-
     }
 }
 
-internal class ValidationNode<T>(
-    private val constraints: List<Constraint<T>>,
-    private val subValidations: List<Validation<T>>
-) : Validation<T> {
-    override fun validate(value: T): ValidationResult<T> {
-        val subValidationResult = applySubValidations(value, keyTransform = { it })
-        val localValidationResult = localValidation(value)
+internal class ValidationNode<C, T>(
+    private val constraints: List<Constraint<C, T>>,
+    private val subValidations: List<Validation<C, T>>
+) : Validation<C, T> {
+    override fun validate(context: C, value: T): ValidationResult<T> {
+        val subValidationResult = applySubValidations(context, value, keyTransform = { it })
+        val localValidationResult = localValidation(context, value)
         return localValidationResult.combineWith(subValidationResult)
     }
 
-    private fun localValidation(value: T): ValidationResult<T> {
+    private fun localValidation(context: C, value: T): ValidationResult<T> {
         return constraints
-            .filter { !it.test(value) }
+            .filter { !it.test(context, value) }
             .map { constructHint(value, it) }
             .let { errors ->
                 if (errors.isEmpty()) {
@@ -116,15 +113,15 @@ internal class ValidationNode<T>(
             }
     }
 
-    private fun constructHint(value: T, it: Constraint<T>): String {
+    private fun constructHint(value: T, it: Constraint<C, T>): String {
         val replaceValue = it.hint.replace("{value}", value.toString())
         return it.templateValues
             .foldIndexed(replaceValue) { index, hint, templateValue -> hint.replace("{$index}", templateValue) }
     }
 
-    private fun applySubValidations(propertyValue: T, keyTransform: (String) -> String): ValidationResult<T> {
+    private fun applySubValidations(context: C, propertyValue: T, keyTransform: (String) -> String): ValidationResult<T> {
         return subValidations.fold(Valid(propertyValue)) { existingValidation: ValidationResult<T>, validation ->
-            val newValidation = validation.validate(propertyValue).mapError(keyTransform)
+            val newValidation = validation.validate(context, propertyValue).mapError(keyTransform)
             existingValidation.combineWith(newValidation)
         }
     }

--- a/src/commonMain/kotlin/io/konform/validation/internal/Validation.kt
+++ b/src/commonMain/kotlin/io/konform/validation/internal/Validation.kt
@@ -1,112 +1,104 @@
 package io.konform.validation.internal
 
-import io.konform.validation.Invalid
-import io.konform.validation.Valid
-import io.konform.validation.Validation
-import io.konform.validation.ValidationResult
+import io.konform.validation.*
 
-internal class MappedContextValidation<C, S, T>(
-    private val validation: Validation<S, T>,
+internal class MappedContextValidation<C, S, T, E>(
+    private val validation: Validation<S, T, E>,
     private val map: (C) -> S,
-) : Validation<C, T> {
-    override fun validate(context: C, value: T): ValidationResult<T> =
+) : Validation<C, T, E> {
+    override fun validate(context: C, value: T): ValidationResult<E, T> =
         validation(map(context), value)
 }
 
-internal class MappedValidation<C, T, V>(
-    private val validation: Validation<C, V>,
+internal class MappedValidation<C, T, V, E>(
+    private val validation: Validation<C, V, E>,
     private val name: String,
     private val mapFn: (T) -> V,
-) : Validation<C, T> {
-    override fun validate(context: C, value: T): ValidationResult<T> =
+) : Validation<C, T, E> {
+    override fun validate(context: C, value: T): ValidationResult<E, T> =
         validation(context, mapFn(value))
             .mapError { ".$name$it" }
             .map { value }
 }
 
-internal class OptionalValidation<C, T : Any>(
-    private val validation: Validation<C, T>
-) : Validation<C, T?> {
-    override fun validate(context: C, value: T?): ValidationResult<T?> {
+internal class OptionalValidation<C, T : Any, E>(
+    private val validation: Validation<C, T, E>
+) : Validation<C, T?, E> {
+    override fun validate(context: C, value: T?): ValidationResult<E, T?> {
         val nonNullValue = value ?: return Valid(value)
         return validation(context, nonNullValue)
     }
 }
 
-internal class RequiredValidation<C, T: Any>(
-    private val validation: Validation<C, T>
-) : Validation<C, T?> {
-    override fun validate(context: C, value: T?): ValidationResult<T?> {
-        val nonNullValue = value
-            ?: return Invalid(mapOf("" to listOf("is required")))
-        return validation(context, nonNullValue)
+internal class RequiredValidation<C, T: Any, E>(
+    private val requiredValidation: Validation<C, T?, E>,
+    private val subValidation: Validation<C, T, E>,
+) : Validation<C, T?, E> {
+    override fun validate(context: C, value: T?): ValidationResult<E, T?> {
+        return requiredValidation.validate(context, value)
+            .flatMap {
+                subValidation(context, it!!)
+            }
     }
 }
 
-internal class IterableValidation<C, T>(
-    private val validation: Validation<C, T>
-) : Validation<C, Iterable<T>> {
-    override fun validate(context: C, value: Iterable<T>): ValidationResult<Iterable<T>> {
-        return value.foldIndexed(Valid(value)) { index, result: ValidationResult<Iterable<T>>, propertyValue ->
+internal class IterableValidation<C, T, E>(
+    private val validation: Validation<C, T, E>
+) : Validation<C, Iterable<T>, E> {
+    override fun validate(context: C, value: Iterable<T>): ValidationResult<E, Iterable<T>> {
+        return value.foldIndexed(Valid(value)) { index, result: ValidationResult<E, Iterable<T>>, propertyValue ->
             val propertyValidation = validation(context, propertyValue).mapError { "[$index]$it" }.map { value }
             result.combineWith(propertyValidation)
         }
     }
 }
 
-internal class ArrayValidation<C, T>(
-    private val validation: Validation<C, T>
-) : Validation<C, Array<T>> {
-    override fun validate(context: C, value: Array<T>): ValidationResult<Array<T>> {
-        return value.foldIndexed(Valid(value)) { index, result: ValidationResult<Array<T>>, propertyValue ->
+internal class ArrayValidation<C, T, E>(
+    private val validation: Validation<C, T, E>
+) : Validation<C, Array<T>, E> {
+    override fun validate(context: C, value: Array<T>): ValidationResult<E, Array<T>> {
+        return value.foldIndexed(Valid(value)) { index, result: ValidationResult<E, Array<T>>, propertyValue ->
             val propertyValidation = validation(context, propertyValue).mapError { "[$index]$it" }.map { value }
             result.combineWith(propertyValidation)
         }
     }
 }
 
-internal class MapValidation<C, K, V>(
-    private val validation: Validation<C, Map.Entry<K, V>>
-) : Validation<C, Map<K, V>> {
-    override fun validate(context: C, value: Map<K, V>): ValidationResult<Map<K, V>> {
-        return value.asSequence().fold(Valid(value)) { result: ValidationResult<Map<K, V>>, entry ->
+internal class MapValidation<C, K, V, E>(
+    private val validation: Validation<C, Map.Entry<K, V>, E>
+) : Validation<C, Map<K, V>, E> {
+    override fun validate(context: C, value: Map<K, V>): ValidationResult<E, Map<K, V>> {
+        return value.asSequence().fold(Valid(value)) { result: ValidationResult<E, Map<K, V>>, entry ->
             val propertyValidation = validation(context, entry).mapError { ".${entry.key.toString()}${it.removePrefix(".value")}" }.map { value }
             result.combineWith(propertyValidation)
         }
     }
 }
 
-internal data class ConstraintValidation<C, T>(
-    private val hint: String,
-    private val templateValues: List<String>,
+internal data class ConstraintValidation<C, T, E>(
+    private val hint: HintBuilder<C, T, E>,
+    private val arguments: HintArguments,
     private val test: (C, T) -> Boolean,
-) : Validation<C, T> {
-    override fun validate(context: C, value: T): ValidationResult<T> =
+) : Validation<C, T, E> {
+    override fun validate(context: C, value: T): ValidationResult<E, T> =
         if (test(context, value)) {
             Valid(value)
         } else {
-            Invalid(mapOf("" to listOf(constructHint(value))))
+            Invalid(mapOf("" to listOf(context.hint(value, arguments))))
         }
-
-    private fun constructHint(value: T): String {
-        val replaceValue = hint.replace("{value}", value.toString())
-        return templateValues
-            .foldIndexed(replaceValue) { index, hint, templateValue -> hint.replace("{$index}", templateValue) }
-    }
-
 }
 
-internal class ValidationNode<C, T>(
-    private val subValidations: List<Validation<C, T>>
-) : Validation<C, T> {
-    override fun validate(context: C, value: T): ValidationResult<T> =
-        subValidations.fold(Valid(value)) { existingValidation: ValidationResult<T>, validation ->
+internal class ValidationNode<C, T, E>(
+    private val subValidations: List<Validation<C, T, E>>
+) : Validation<C, T, E> {
+    override fun validate(context: C, value: T): ValidationResult<E, T> =
+        subValidations.fold(Valid(value)) { existingValidation: ValidationResult<E, T>, validation ->
             val newValidation = validation.validate(context, value).mapError(::identity)
             existingValidation.combineWith(newValidation)
         }
 }
 
-internal fun <R> ValidationResult<R>.mapError(keyTransform: (String) -> String): ValidationResult<R> {
+internal fun <R, E> ValidationResult<R, E>.mapError(keyTransform: (String) -> String): ValidationResult<R, E> {
     return when (this) {
         is Valid -> this
         is Invalid -> Invalid(this.internalErrors.mapKeys { (key, _) ->
@@ -115,7 +107,7 @@ internal fun <R> ValidationResult<R>.mapError(keyTransform: (String) -> String):
     }
 }
 
-internal fun <R> ValidationResult<R>.combineWith(other: ValidationResult<R>): ValidationResult<R> {
+internal fun <R, E> ValidationResult<R, E>.combineWith(other: ValidationResult<R, E>): ValidationResult<R, E> {
     return when (this) {
         is Valid -> return other
         is Invalid -> when (other) {

--- a/src/commonMain/kotlin/io/konform/validation/jsonschema/JsonSchema.kt
+++ b/src/commonMain/kotlin/io/konform/validation/jsonschema/JsonSchema.kt
@@ -117,6 +117,14 @@ fun <C, T : Iterable<*>, E> ValidationBuilder<C, T, E>.minItems(hint: HintBuilde
 fun <C, T : Iterable<*>> ValidationBuilder<C, T, String>.minItems(minSize: Int) =
     minItems(stringHintBuilder(minItemsTemplate), minSize)
 
+@JvmName("minItemsArray")
+fun <C, T, E> ValidationBuilder<C, Array<T>, E>.minItems(hint: HintBuilder<C, Array<T>, E>, minSize: Int) =
+    addConstraint(hint, minSize) { it.count() >= minSize }
+
+@JvmName("minItemsArray")
+fun <C, T> ValidationBuilder<C, Array<T>, String>.minItems(minSize: Int) =
+    minItems(stringHintBuilder(minItemsTemplate), minSize)
+
 @JvmName("minItemsMap")
 fun <C, T : Map<*, *>, E> ValidationBuilder<C, T, E>.minItems(hint: HintBuilder<C, T, E>, minSize: Int) =
     addConstraint(hint, minSize) { it.count() >= minSize }
@@ -134,6 +142,14 @@ fun <C, T : Iterable<*>, E> ValidationBuilder<C, T, E>.maxItems(hint: HintBuilde
 
 @JvmName("maxItemsIterable")
 fun <C, T : Iterable<*>> ValidationBuilder<C, T, String>.maxItems(maxSize: Int) =
+    maxItems(stringHintBuilder(maxItemsTemplate), maxSize)
+
+@JvmName("maxItemsArray")
+fun <C, T, E> ValidationBuilder<C, Array<T>, E>.maxItems(hint: HintBuilder<C, Array<T>, E>, maxSize: Int) =
+    addConstraint(hint, maxSize) { it.count() <= maxSize }
+
+@JvmName("maxItemsArray")
+fun <C, T> ValidationBuilder<C, Array<T>, String>.maxItems(maxSize: Int) =
     maxItems(stringHintBuilder(maxItemsTemplate), maxSize)
 
 @JvmName("maxItemsMap")
@@ -165,4 +181,12 @@ fun <C, T : Iterable<*>, E> ValidationBuilder<C, T, E>.uniqueItems(hint: HintBui
 
 @JvmName("uniqueItemsIterable")
 fun <C, T : Iterable<*>> ValidationBuilder<C, T, String>.uniqueItems(unique: Boolean) =
+    uniqueItems(stringHintBuilder(uniqueItemsTemplate), unique)
+
+@JvmName("uniqueItemsArray")
+fun <C, T, E> ValidationBuilder<C, Array<T>, E>.uniqueItems(hint: HintBuilder<C, Array<T>, E>, unique: Boolean) =
+    addConstraint(hint, unique) { !unique || it.distinct().count() == it.count() }
+
+@JvmName("uniqueItemsArray")
+fun <C, T> ValidationBuilder<C, Array<T>, String>.uniqueItems(unique: Boolean) =
     uniqueItems(stringHintBuilder(uniqueItemsTemplate), unique)

--- a/src/commonMain/kotlin/io/konform/validation/jsonschema/JsonSchema.kt
+++ b/src/commonMain/kotlin/io/konform/validation/jsonschema/JsonSchema.kt
@@ -1,6 +1,6 @@
 package io.konform.validation.jsonschema
 
-import io.konform.validation.Constraint
+import io.konform.validation.ConstraintBuilder
 import io.konform.validation.ValidationBuilder
 import kotlin.jvm.JvmName
 import kotlin.math.roundToInt
@@ -19,7 +19,7 @@ fun <C, T> ValidationBuilder<C, T>.enum(vararg allowed: T) =
         allowed.joinToString("', '", "'", "'")
     ) { it in allowed }
 
-inline fun <C, reified T : Enum<T>> ValidationBuilder<C, String>.enum(): Constraint<*, String> {
+inline fun <C, reified T : Enum<T>> ValidationBuilder<C, String>.enum(): ConstraintBuilder {
     val enumNames = enumValues<T>().map { it.name }
     return addConstraint(
         "must be one of: {0}",
@@ -28,7 +28,7 @@ inline fun <C, reified T : Enum<T>> ValidationBuilder<C, String>.enum(): Constra
 }
 
 @JvmName("simpleEnum")
-inline fun <reified T : Enum<T>> ValidationBuilder<Unit, String>.enum(): Constraint<*, String> = enum<Unit, T>()
+inline fun <reified T : Enum<T>> ValidationBuilder<Unit, String>.enum(): ConstraintBuilder = enum<Unit, T>()
 
 fun <C, T> ValidationBuilder<C, T>.const(expected: T) =
     addConstraint(
@@ -37,7 +37,7 @@ fun <C, T> ValidationBuilder<C, T>.const(expected: T) =
     ) { expected == it }
 
 
-fun <C, T : Number> ValidationBuilder<C, T>.multipleOf(factor: Number): Constraint<C, T> {
+fun <C, T : Number> ValidationBuilder<C, T>.multipleOf(factor: Number): ConstraintBuilder {
     val factorAsDouble = factor.toDouble()
     require(factorAsDouble > 0) { "multipleOf requires the factor to be strictly larger than 0" }
     return addConstraint("must be a multiple of '{0}'", factor.toString()) {
@@ -66,7 +66,7 @@ fun <C, T : Number> ValidationBuilder<C, T>.exclusiveMinimum(minimumExclusive: N
     minimumExclusive.toString()
 ) { it.toDouble() > minimumExclusive.toDouble() }
 
-fun <C> ValidationBuilder<C, String>.minLength(length: Int): Constraint<C, String> {
+fun <C> ValidationBuilder<C, String>.minLength(length: Int): ConstraintBuilder {
     require(length >= 0) { IllegalArgumentException("minLength requires the length to be >= 0") }
     return addConstraint(
         "must have at least {0} characters",
@@ -74,7 +74,7 @@ fun <C> ValidationBuilder<C, String>.minLength(length: Int): Constraint<C, Strin
     ) { it.length >= length }
 }
 
-fun <C> ValidationBuilder<C, String>.maxLength(length: Int): Constraint<*, String> {
+fun <C> ValidationBuilder<C, String>.maxLength(length: Int): ConstraintBuilder {
     require(length >= 0) { IllegalArgumentException("maxLength requires the length to be >= 0") }
     return addConstraint(
         "must have at most {0} characters",
@@ -90,7 +90,7 @@ fun <C> ValidationBuilder<C, String>.pattern(pattern: Regex) = addConstraint(
 ) { it.matches(pattern) }
 
 
-inline fun <C, reified T> ValidationBuilder<C, T>.minItems(minSize: Int): Constraint<C, T> = addConstraint(
+inline fun <C, reified T> ValidationBuilder<C, T>.minItems(minSize: Int): ConstraintBuilder = addConstraint(
     "must have at least {0} items",
     minSize.toString()
 ) {
@@ -103,7 +103,7 @@ inline fun <C, reified T> ValidationBuilder<C, T>.minItems(minSize: Int): Constr
 }
 
 
-inline fun <C, reified T> ValidationBuilder<C, T>.maxItems(maxSize: Int): Constraint<C, T> = addConstraint(
+inline fun <C, reified T> ValidationBuilder<C, T>.maxItems(maxSize: Int): ConstraintBuilder = addConstraint(
     "must have at most {0} items",
     maxSize.toString()
 ) {
@@ -115,13 +115,13 @@ inline fun <C, reified T> ValidationBuilder<C, T>.maxItems(maxSize: Int): Constr
     }
 }
 
-inline fun <C, reified T: Map<*, *>> ValidationBuilder<C, T>.minProperties(minSize: Int): Constraint<C, T> =
+inline fun <C, reified T: Map<*, *>> ValidationBuilder<C, T>.minProperties(minSize: Int): ConstraintBuilder =
     minItems(minSize) hint "must have at least {0} properties"
 
-inline fun <C, reified T: Map<*, *>> ValidationBuilder<C, T>.maxProperties(maxSize: Int): Constraint<C, T> =
+inline fun <C, reified T: Map<*, *>> ValidationBuilder<C, T>.maxProperties(maxSize: Int): ConstraintBuilder =
     maxItems(maxSize) hint "must have at most {0} properties"
 
-inline fun <C, reified T> ValidationBuilder<C, T>.uniqueItems(unique: Boolean): Constraint<C, T> = addConstraint(
+inline fun <C, reified T> ValidationBuilder<C, T>.uniqueItems(unique: Boolean): ConstraintBuilder = addConstraint(
     "all items must be unique"
 ) {
     !unique || when (it) {

--- a/src/commonMain/kotlin/io/konform/validation/jsonschema/JsonSchema.kt
+++ b/src/commonMain/kotlin/io/konform/validation/jsonschema/JsonSchema.kt
@@ -6,7 +6,7 @@ import kotlin.jvm.JvmName
 import kotlin.math.roundToInt
 
 inline fun <C, reified T> ValidationBuilder<C, *>.type() =
-    addSimpleConstraint(
+    addConstraint(
         "must be of the correct type"
     ) { it is T }
 
@@ -14,14 +14,14 @@ inline fun <C, reified T> ValidationBuilder<C, *>.type() =
 inline fun <reified T> ValidationBuilder<Unit, *>.type() = type<Unit, T>()
 
 fun <C, T> ValidationBuilder<C, T>.enum(vararg allowed: T) =
-    addSimpleConstraint(
+    addConstraint(
         "must be one of: {0}",
         allowed.joinToString("', '", "'", "'")
     ) { it in allowed }
 
 inline fun <C, reified T : Enum<T>> ValidationBuilder<C, String>.enum(): Constraint<*, String> {
     val enumNames = enumValues<T>().map { it.name }
-    return addSimpleConstraint(
+    return addConstraint(
         "must be one of: {0}",
         enumNames.joinToString("', '", "'", "'")
     ) { it in enumNames }
@@ -31,7 +31,7 @@ inline fun <C, reified T : Enum<T>> ValidationBuilder<C, String>.enum(): Constra
 inline fun <reified T : Enum<T>> ValidationBuilder<Unit, String>.enum(): Constraint<*, String> = enum<Unit, T>()
 
 fun <C, T> ValidationBuilder<C, T>.const(expected: T) =
-    addSimpleConstraint(
+    addConstraint(
         "must be {0}",
         expected?.let { "'$it'" } ?: "null"
     ) { expected == it }
@@ -40,35 +40,35 @@ fun <C, T> ValidationBuilder<C, T>.const(expected: T) =
 fun <C, T : Number> ValidationBuilder<C, T>.multipleOf(factor: Number): Constraint<C, T> {
     val factorAsDouble = factor.toDouble()
     require(factorAsDouble > 0) { "multipleOf requires the factor to be strictly larger than 0" }
-    return addSimpleConstraint("must be a multiple of '{0}'", factor.toString()) {
+    return addConstraint("must be a multiple of '{0}'", factor.toString()) {
         val division = it.toDouble() / factorAsDouble
         division.compareTo(division.roundToInt()) == 0
     }
 }
 
-fun <C, T : Number> ValidationBuilder<C, T>.maximum(maximumInclusive: Number) = addSimpleConstraint(
+fun <C, T : Number> ValidationBuilder<C, T>.maximum(maximumInclusive: Number) = addConstraint(
     "must be at most '{0}'",
     maximumInclusive.toString()
 ) { it.toDouble() <= maximumInclusive.toDouble() }
 
-fun <C, T : Number> ValidationBuilder<C, T>.exclusiveMaximum(maximumExclusive: Number) = addSimpleConstraint(
+fun <C, T : Number> ValidationBuilder<C, T>.exclusiveMaximum(maximumExclusive: Number) = addConstraint(
     "must be less than '{0}'",
     maximumExclusive.toString()
 ) { it.toDouble() < maximumExclusive.toDouble() }
 
-fun <C, T : Number> ValidationBuilder<C, T>.minimum(minimumInclusive: Number) = addSimpleConstraint(
+fun <C, T : Number> ValidationBuilder<C, T>.minimum(minimumInclusive: Number) = addConstraint(
     "must be at least '{0}'",
     minimumInclusive.toString()
 ) { it.toDouble() >= minimumInclusive.toDouble() }
 
-fun <C, T : Number> ValidationBuilder<C, T>.exclusiveMinimum(minimumExclusive: Number) = addSimpleConstraint(
+fun <C, T : Number> ValidationBuilder<C, T>.exclusiveMinimum(minimumExclusive: Number) = addConstraint(
     "must be greater than '{0}'",
     minimumExclusive.toString()
 ) { it.toDouble() > minimumExclusive.toDouble() }
 
 fun <C> ValidationBuilder<C, String>.minLength(length: Int): Constraint<C, String> {
     require(length >= 0) { IllegalArgumentException("minLength requires the length to be >= 0") }
-    return addSimpleConstraint(
+    return addConstraint(
         "must have at least {0} characters",
         length.toString()
     ) { it.length >= length }
@@ -76,7 +76,7 @@ fun <C> ValidationBuilder<C, String>.minLength(length: Int): Constraint<C, Strin
 
 fun <C> ValidationBuilder<C, String>.maxLength(length: Int): Constraint<*, String> {
     require(length >= 0) { IllegalArgumentException("maxLength requires the length to be >= 0") }
-    return addSimpleConstraint(
+    return addConstraint(
         "must have at most {0} characters",
         length.toString()
     ) { it.length <= length }
@@ -84,13 +84,13 @@ fun <C> ValidationBuilder<C, String>.maxLength(length: Int): Constraint<*, Strin
 
 fun <C> ValidationBuilder<C, String>.pattern(pattern: String) = pattern(pattern.toRegex())
 
-fun <C> ValidationBuilder<C, String>.pattern(pattern: Regex) = addSimpleConstraint(
+fun <C> ValidationBuilder<C, String>.pattern(pattern: Regex) = addConstraint(
     "must match the expected pattern",
     pattern.toString()
 ) { it.matches(pattern) }
 
 
-inline fun <C, reified T> ValidationBuilder<C, T>.minItems(minSize: Int): Constraint<C, T> = addSimpleConstraint(
+inline fun <C, reified T> ValidationBuilder<C, T>.minItems(minSize: Int): Constraint<C, T> = addConstraint(
     "must have at least {0} items",
     minSize.toString()
 ) {
@@ -103,7 +103,7 @@ inline fun <C, reified T> ValidationBuilder<C, T>.minItems(minSize: Int): Constr
 }
 
 
-inline fun <C, reified T> ValidationBuilder<C, T>.maxItems(maxSize: Int): Constraint<C, T> = addSimpleConstraint(
+inline fun <C, reified T> ValidationBuilder<C, T>.maxItems(maxSize: Int): Constraint<C, T> = addConstraint(
     "must have at most {0} items",
     maxSize.toString()
 ) {
@@ -121,7 +121,7 @@ inline fun <C, reified T: Map<*, *>> ValidationBuilder<C, T>.minProperties(minSi
 inline fun <C, reified T: Map<*, *>> ValidationBuilder<C, T>.maxProperties(maxSize: Int): Constraint<C, T> =
     maxItems(maxSize) hint "must have at most {0} properties"
 
-inline fun <C, reified T> ValidationBuilder<C, T>.uniqueItems(unique: Boolean): Constraint<C, T> = addSimpleConstraint(
+inline fun <C, reified T> ValidationBuilder<C, T>.uniqueItems(unique: Boolean): Constraint<C, T> = addConstraint(
     "all items must be unique"
 ) {
     !unique || when (it) {

--- a/src/commonMain/kotlin/io/konform/validation/jsonschema/JsonSchema.kt
+++ b/src/commonMain/kotlin/io/konform/validation/jsonschema/JsonSchema.kt
@@ -9,7 +9,7 @@ inline fun <C, reified T, E> ValidationBuilder<C, *, E>.type(noinline hint: Hint
 
 @JvmName("simpleType")
 inline fun <reified T> ValidationBuilder<Unit, *, String>.type() =
-    type<Unit, T, String>(stringHintBuilder("must be of the correct type"))
+    type<Unit, T, String>(stringHint("must be of the correct type"))
 
 fun <C, T> enumHintBuilder(): HintBuilder<C, T, String> = { _, arguments ->
     @Suppress("UNCHECKED_CAST")
@@ -41,7 +41,7 @@ fun <C, T, E> ValidationBuilder<C, T, E>.const(hint: HintBuilder<C, T, E>, expec
     addConstraint(hint, expected?.let { "'$it'" } ?: "null") { expected == it }
 
 fun <C, T> ValidationBuilder<C, T, String>.const(expected: T) =
-    const(stringHintBuilder("must be {0}"), expected)
+    const(stringHint("must be {0}"), expected)
 
 fun <C, T : Number, E> ValidationBuilder<C, T, E>.multipleOf(hint: HintBuilder<C, T, E>, factor: Number): ConstraintBuilder<C, T, E> {
     val factorAsDouble = factor.toDouble()
@@ -53,39 +53,39 @@ fun <C, T : Number, E> ValidationBuilder<C, T, E>.multipleOf(hint: HintBuilder<C
 }
 
 fun <C, T : Number> ValidationBuilder<C, T, String>.multipleOf(factor: Number): ConstraintBuilder<C, T, String> =
-    multipleOf(stringHintBuilder("must be a multiple of '{0}'"), factor)
+    multipleOf(stringHint("must be a multiple of '{0}'"), factor)
 
 
 fun <C, T : Number, E> ValidationBuilder<C, T, E>.maximum(hint: HintBuilder<C, T, E>, maximumInclusive: Number) =
     addConstraint(hint, maximumInclusive) { it.toDouble() <= maximumInclusive.toDouble() }
 
 fun <C, T : Number> ValidationBuilder<C, T, String>.maximum(maximumInclusive: Number) =
-    maximum(stringHintBuilder("must be at most '{0}'"), maximumInclusive)
+    maximum(stringHint("must be at most '{0}'"), maximumInclusive)
 
 fun <C, T : Number, E> ValidationBuilder<C, T, E>.exclusiveMaximum(hint: HintBuilder<C, T, E>, maximumExclusive: Number) =
     addConstraint(hint, maximumExclusive) { it.toDouble() < maximumExclusive.toDouble() }
 
 fun <C, T : Number> ValidationBuilder<C, T, String>.exclusiveMaximum(maximumExclusive: Number) =
-    exclusiveMaximum(stringHintBuilder("must be less than '{0}'"), maximumExclusive)
+    exclusiveMaximum(stringHint("must be less than '{0}'"), maximumExclusive)
 
 fun <C, T : Number, E> ValidationBuilder<C, T, E>.minimum(hint: HintBuilder<C, T, E>, minimumInclusive: Number) =
     addConstraint(hint, minimumInclusive) { it.toDouble() >= minimumInclusive.toDouble() }
 
 fun <C, T : Number> ValidationBuilder<C, T, String>.minimum(minimumInclusive: Number) =
-    minimum(stringHintBuilder("must be at least '{0}'"), minimumInclusive)
+    minimum(stringHint("must be at least '{0}'"), minimumInclusive)
 
 fun <C, T : Number, E> ValidationBuilder<C, T, E>.exclusiveMinimum(hint: HintBuilder<C, T, E>, minimumExclusive: Number) =
     addConstraint(hint, minimumExclusive) { it.toDouble() > minimumExclusive.toDouble() }
 
 fun <C, T : Number> ValidationBuilder<C, T, String>.exclusiveMinimum(minimumExclusive: Number) =
-    exclusiveMinimum(stringHintBuilder("must be greater than '{0}'"), minimumExclusive)
+    exclusiveMinimum(stringHint("must be greater than '{0}'"), minimumExclusive)
 
 fun <C, E> ValidationBuilder<C, String, E>.minLength(hint: HintBuilder<C, String, E>, length: Int): ConstraintBuilder<C, String, E> {
     require(length >= 0) { IllegalArgumentException("minLength requires the length to be >= 0") }
     return addConstraint(hint, length) { it.length >= length }
 }
 fun <C> ValidationBuilder<C, String, String>.minLength(length: Int) =
-    minLength(stringHintBuilder("must have at least {0} characters"), length)
+    minLength(stringHint("must have at least {0} characters"), length)
 
 fun <C, E> ValidationBuilder<C, String, E>.maxLength(hint: HintBuilder<C, String, E>, length: Int): ConstraintBuilder<C, String, E> {
     require(length >= 0) { IllegalArgumentException("maxLength requires the length to be >= 0") }
@@ -93,13 +93,13 @@ fun <C, E> ValidationBuilder<C, String, E>.maxLength(hint: HintBuilder<C, String
 }
 
 fun <C> ValidationBuilder<C, String, String>.maxLength(length: Int) =
-    maxLength(stringHintBuilder("must have at most {0} characters"), length)
+    maxLength(stringHint("must have at most {0} characters"), length)
 
 fun <C, E> ValidationBuilder<C, String, E>.pattern(hint: HintBuilder<C, String, E>, pattern: Regex) =
     addConstraint(hint, pattern) { it.matches(pattern) }
 
 fun <C> ValidationBuilder<C, String, String>.pattern(pattern: Regex) =
-    pattern(stringHintBuilder("must match the expected pattern"), pattern)
+    pattern(stringHint("must match the expected pattern"), pattern)
 
 fun <C, E> ValidationBuilder<C, String, E>.pattern(hint: HintBuilder<C, String, E>, pattern: String) =
     pattern(hint, pattern.toRegex())
@@ -115,7 +115,7 @@ fun <C, T : Iterable<*>, E> ValidationBuilder<C, T, E>.minItems(hint: HintBuilde
 
 @JvmName("minItemsIterable")
 fun <C, T : Iterable<*>> ValidationBuilder<C, T, String>.minItems(minSize: Int) =
-    minItems(stringHintBuilder(minItemsTemplate), minSize)
+    minItems(stringHint(minItemsTemplate), minSize)
 
 @JvmName("minItemsArray")
 fun <C, T, E> ValidationBuilder<C, Array<T>, E>.minItems(hint: HintBuilder<C, Array<T>, E>, minSize: Int) =
@@ -123,7 +123,7 @@ fun <C, T, E> ValidationBuilder<C, Array<T>, E>.minItems(hint: HintBuilder<C, Ar
 
 @JvmName("minItemsArray")
 fun <C, T> ValidationBuilder<C, Array<T>, String>.minItems(minSize: Int) =
-    minItems(stringHintBuilder(minItemsTemplate), minSize)
+    minItems(stringHint(minItemsTemplate), minSize)
 
 @JvmName("minItemsMap")
 fun <C, T : Map<*, *>, E> ValidationBuilder<C, T, E>.minItems(hint: HintBuilder<C, T, E>, minSize: Int) =
@@ -131,7 +131,7 @@ fun <C, T : Map<*, *>, E> ValidationBuilder<C, T, E>.minItems(hint: HintBuilder<
 
 @JvmName("minItemsMap")
 fun <C, T : Map<*, *>> ValidationBuilder<C, T, String>.minItems(minSize: Int) =
-    minItems(stringHintBuilder(minItemsTemplate), minSize)
+    minItems(stringHint(minItemsTemplate), minSize)
 
 
 private const val maxItemsTemplate = "must have at most {0} items"
@@ -142,7 +142,7 @@ fun <C, T : Iterable<*>, E> ValidationBuilder<C, T, E>.maxItems(hint: HintBuilde
 
 @JvmName("maxItemsIterable")
 fun <C, T : Iterable<*>> ValidationBuilder<C, T, String>.maxItems(maxSize: Int) =
-    maxItems(stringHintBuilder(maxItemsTemplate), maxSize)
+    maxItems(stringHint(maxItemsTemplate), maxSize)
 
 @JvmName("maxItemsArray")
 fun <C, T, E> ValidationBuilder<C, Array<T>, E>.maxItems(hint: HintBuilder<C, Array<T>, E>, maxSize: Int) =
@@ -150,7 +150,7 @@ fun <C, T, E> ValidationBuilder<C, Array<T>, E>.maxItems(hint: HintBuilder<C, Ar
 
 @JvmName("maxItemsArray")
 fun <C, T> ValidationBuilder<C, Array<T>, String>.maxItems(maxSize: Int) =
-    maxItems(stringHintBuilder(maxItemsTemplate), maxSize)
+    maxItems(stringHint(maxItemsTemplate), maxSize)
 
 @JvmName("maxItemsMap")
 fun <C, T : Map<*, *>, E> ValidationBuilder<C, T, E>.maxItems(hint: HintBuilder<C, T, E>, maxSize: Int) =
@@ -158,19 +158,19 @@ fun <C, T : Map<*, *>, E> ValidationBuilder<C, T, E>.maxItems(hint: HintBuilder<
 
 @JvmName("maxItemsMap")
 fun <C, T : Map<*, *>> ValidationBuilder<C, T, String>.maxItems(maxSize: Int) =
-    maxItems(stringHintBuilder(maxItemsTemplate), maxSize)
+    maxItems(stringHint(maxItemsTemplate), maxSize)
 
 fun <C, T : Map<*, *>, E> ValidationBuilder<C, T, E>.minProperties(hint: HintBuilder<C, T, E>, minSize: Int) =
     minItems(hint, minSize)
 
 fun <C, T : Map<*, *>> ValidationBuilder<C, T, String>.minProperties(minSize: Int) =
-    minProperties(stringHintBuilder("must have at least {0} properties"), minSize)
+    minProperties(stringHint("must have at least {0} properties"), minSize)
 
 fun <C, T : Map<*, *>, E> ValidationBuilder<C, T, E>.maxProperties(hint: HintBuilder<C, T, E>, maxSize: Int) =
     maxItems(hint, maxSize)
 
 fun <C, T : Map<*, *>> ValidationBuilder<C, T, String>.maxProperties(maxSize: Int) =
-    maxProperties(stringHintBuilder("must have at most {0} properties"), maxSize)
+    maxProperties(stringHint("must have at most {0} properties"), maxSize)
 
 
 private const val uniqueItemsTemplate = "all items must be unique"
@@ -181,7 +181,7 @@ fun <C, T : Iterable<*>, E> ValidationBuilder<C, T, E>.uniqueItems(hint: HintBui
 
 @JvmName("uniqueItemsIterable")
 fun <C, T : Iterable<*>> ValidationBuilder<C, T, String>.uniqueItems(unique: Boolean) =
-    uniqueItems(stringHintBuilder(uniqueItemsTemplate), unique)
+    uniqueItems(stringHint(uniqueItemsTemplate), unique)
 
 @JvmName("uniqueItemsArray")
 fun <C, T, E> ValidationBuilder<C, Array<T>, E>.uniqueItems(hint: HintBuilder<C, Array<T>, E>, unique: Boolean) =
@@ -189,4 +189,4 @@ fun <C, T, E> ValidationBuilder<C, Array<T>, E>.uniqueItems(hint: HintBuilder<C,
 
 @JvmName("uniqueItemsArray")
 fun <C, T> ValidationBuilder<C, Array<T>, String>.uniqueItems(unique: Boolean) =
-    uniqueItems(stringHintBuilder(uniqueItemsTemplate), unique)
+    uniqueItems(stringHint(uniqueItemsTemplate), unique)

--- a/src/commonTest/kotlin/io/konform/validation/JSONSchemaStyleConstraintsTest.kt
+++ b/src/commonTest/kotlin/io/konform/validation/JSONSchemaStyleConstraintsTest.kt
@@ -273,13 +273,12 @@ class JSONSchemaStyleConstraintsTest {
 
         assertEquals(1, countFieldsWithErrors(validation(emptyList())))
 
+        val arrayValidation = Validation<Array<String>> { minItems(1) }
 
-//        val arrayValidation = Validation<Array<String>> { minItems(1) }
-//
-//        arrayOf("a", "b").let { assertEquals(Valid(it), arrayValidation(it)) }
-//        arrayOf("a").let { assertEquals(Valid(it), arrayValidation(it)) }
-//
-//        assertEquals(1, countFieldsWithErrors(arrayValidation(emptyArray())))
+        arrayOf("a", "b").let { assertEquals(Valid(it), arrayValidation(it)) }
+        arrayOf("a").let { assertEquals(Valid(it), arrayValidation(it)) }
+
+        assertEquals(1, countFieldsWithErrors(arrayValidation(emptyArray())))
 
         val mapValidation = Validation<Map<String, Int>> { minItems(1) }
 
@@ -300,12 +299,12 @@ class JSONSchemaStyleConstraintsTest {
 
         assertEquals(1, countFieldsWithErrors(validation(listOf("a", "b"))))
 
-//        val arrayValidation = Validation<Array<String>> { maxItems(1) }
-//
-//        emptyArray<String>().let { assertEquals(Valid(it), arrayValidation(it)) }
-//        arrayOf("a").let { assertEquals(Valid(it), arrayValidation(it)) }
-//
-//        assertEquals(1, countFieldsWithErrors(arrayValidation(arrayOf("a", "b"))))
+        val arrayValidation = Validation<Array<String>> { maxItems(1) }
+
+        emptyArray<String>().let { assertEquals(Valid(it), arrayValidation(it)) }
+        arrayOf("a").let { assertEquals(Valid(it), arrayValidation(it)) }
+
+        assertEquals(1, countFieldsWithErrors(arrayValidation(arrayOf("a", "b"))))
 
         val mapValidation = Validation<Map<String, Int>> { maxItems(1) }
 
@@ -351,13 +350,13 @@ class JSONSchemaStyleConstraintsTest {
 
         assertEquals(1, countFieldsWithErrors(validation(listOf("a", "a"))))
 
-//        val arrayValidation = Validation<Array<String>> { uniqueItems(true) }
-//
-//        emptyArray<String>().let { assertEquals(Valid(it), arrayValidation(it)) }
-//        arrayOf("a").let { assertEquals(Valid(it), arrayValidation(it)) }
-//        arrayOf("a", "b").let { assertEquals(Valid(it), arrayValidation(it)) }
-//
-//        assertEquals(1, countFieldsWithErrors(arrayValidation(arrayOf("a", "a"))))
+        val arrayValidation = Validation<Array<String>> { uniqueItems(true) }
+
+        emptyArray<String>().let { assertEquals(Valid(it), arrayValidation(it)) }
+        arrayOf("a").let { assertEquals(Valid(it), arrayValidation(it)) }
+        arrayOf("a", "b").let { assertEquals(Valid(it), arrayValidation(it)) }
+
+        assertEquals(1, countFieldsWithErrors(arrayValidation(arrayOf("a", "a"))))
 
         assertEquals("all items must be unique", validation(listOf("a", "a")).get()!![0])
     }

--- a/src/commonTest/kotlin/io/konform/validation/JSONSchemaStyleConstraintsTest.kt
+++ b/src/commonTest/kotlin/io/konform/validation/JSONSchemaStyleConstraintsTest.kt
@@ -45,6 +45,18 @@ class JSONSchemaStyleConstraintsTest {
     }
 
     @Test
+    fun typeConstraintWithContext() {
+        val anyValidation = Validation<String, Any> { type<String, String>() }
+        assertEquals(
+            Valid("This is a string"),
+            anyValidation("c", "This is a string"))
+
+        assertEquals(1, countFieldsWithErrors(anyValidation("c", 1)))
+        assertEquals(1, countFieldsWithErrors(anyValidation("c", 1.0)))
+        assertEquals(1, countFieldsWithErrors(anyValidation("c", true)))
+    }
+
+    @Test
     fun nullableTypeConstraint() {
         val anyValidation = Validation<Any?> { type<String?>() }
         assertEquals<ValidationResult<Any?>>(
@@ -84,8 +96,15 @@ class JSONSchemaStyleConstraintsTest {
         assertEquals(Valid("SYNACK"), stringifiedEnumValidation("SYNACK"))
         assertEquals(1, countFieldsWithErrors(stringifiedEnumValidation("ASDF")))
 
+        val stringifiedEnumValidationWithContext = Validation<Int, String> { enum<Int, TCPPacket>() }
+        assertEquals(Valid("SYN"), stringifiedEnumValidationWithContext(1, "SYN"))
+        assertEquals(Valid("ACK"), stringifiedEnumValidationWithContext(2, "ACK"))
+        assertEquals(Valid("SYNACK"), stringifiedEnumValidationWithContext(3, "SYNACK"))
+        assertEquals(1, countFieldsWithErrors(stringifiedEnumValidationWithContext(4, "ASDF")))
+
         assertEquals("must be one of: 'SYN', 'ACK'", partialEnumValidation(SYNACK).get()!![0])
         assertEquals("must be one of: 'SYN', 'ACK', 'SYNACK'", stringifiedEnumValidation("").get()!![0])
+        assertEquals("must be one of: 'SYN', 'ACK', 'SYNACK'", stringifiedEnumValidationWithContext(1, "").get()!![0])
     }
 
     @Test

--- a/src/commonTest/kotlin/io/konform/validation/JSONSchemaStyleConstraintsTest.kt
+++ b/src/commonTest/kotlin/io/konform/validation/JSONSchemaStyleConstraintsTest.kt
@@ -1,22 +1,7 @@
 package io.konform.validation
 
 import io.konform.validation.JSONSchemaStyleConstraintsTest.TCPPacket.*
-import io.konform.validation.jsonschema.const
-import io.konform.validation.jsonschema.enum
-import io.konform.validation.jsonschema.exclusiveMaximum
-import io.konform.validation.jsonschema.exclusiveMinimum
-import io.konform.validation.jsonschema.maxItems
-import io.konform.validation.jsonschema.maxLength
-import io.konform.validation.jsonschema.maxProperties
-import io.konform.validation.jsonschema.maximum
-import io.konform.validation.jsonschema.minItems
-import io.konform.validation.jsonschema.minLength
-import io.konform.validation.jsonschema.minProperties
-import io.konform.validation.jsonschema.minimum
-import io.konform.validation.jsonschema.multipleOf
-import io.konform.validation.jsonschema.pattern
-import io.konform.validation.jsonschema.type
-import io.konform.validation.jsonschema.uniqueItems
+import io.konform.validation.jsonschema.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -47,7 +32,7 @@ class JSONSchemaStyleConstraintsTest {
     @Test
     fun genericTypeConstraint() {
         val anyValidation = Validation<String, Any> {
-            type<String, Any, String> { _, t ->  "Expected object of type '$t'" }
+            type<String, String, String> { _, t ->  "Expected object of type '${t[0]}'" }
         }
         assertEquals(
             Valid("This is a string"),
@@ -98,7 +83,7 @@ class JSONSchemaStyleConstraintsTest {
         assertEquals(1, countFieldsWithErrors(stringifiedEnumValidation("ASDF")))
 
         val stringifiedEnumValidationWithContext = Validation<Int, String> {
-            enum<Int, TCPPacket, String> { value, expected -> "$value is not any of $expected"}
+            enum<Int, TCPPacket, String>(enumHintBuilder())
         }
         assertEquals(Valid("SYN"), stringifiedEnumValidationWithContext(1, "SYN"))
         assertEquals(Valid("ACK"), stringifiedEnumValidationWithContext(2, "ACK"))

--- a/src/commonTest/kotlin/io/konform/validation/ReadmeExampleTest.kt
+++ b/src/commonTest/kotlin/io/konform/validation/ReadmeExampleTest.kt
@@ -69,17 +69,17 @@ class ReadmeExampleTest {
                     minLength(2)
                 }
                 Person::age {
-                    minimum(18) hint StringHintBuilder("Attendees must be 18 years or older")
+                    minimum(18) hint stringHintBuilder("Attendees must be 18 years or older")
                 }
                 // Email is optional but if it is set it must be valid
                 Person::email ifPresent {
-                    pattern("\\w+@\\w+\\.\\w+") hint StringHintBuilder("Please provide a valid email address (optional)")
+                    pattern("\\w+@\\w+\\.\\w+") hint stringHintBuilder("Please provide a valid email address (optional)")
                 }
             }
 
             // validation on the ticketPrices Map as a whole
             Event::ticketPrices {
-                minItems(1) hint StringHintBuilder("Provide at least one ticket price")
+                minItems(1) hint stringHintBuilder("Provide at least one ticket price")
             }
 
             // validations for the individual entries

--- a/src/commonTest/kotlin/io/konform/validation/ReadmeExampleTest.kt
+++ b/src/commonTest/kotlin/io/konform/validation/ReadmeExampleTest.kt
@@ -69,17 +69,17 @@ class ReadmeExampleTest {
                     minLength(2)
                 }
                 Person::age {
-                    minimum(18) hint stringHintBuilder("Attendees must be 18 years or older")
+                    minimum(18) hint stringHint("Attendees must be 18 years or older")
                 }
                 // Email is optional but if it is set it must be valid
                 Person::email ifPresent {
-                    pattern("\\w+@\\w+\\.\\w+") hint stringHintBuilder("Please provide a valid email address (optional)")
+                    pattern("\\w+@\\w+\\.\\w+") hint stringHint("Please provide a valid email address (optional)")
                 }
             }
 
             // validation on the ticketPrices Map as a whole
             Event::ticketPrices {
-                minItems(1) hint stringHintBuilder("Provide at least one ticket price")
+                minItems(1) hint stringHint("Provide at least one ticket price")
             }
 
             // validations for the individual entries

--- a/src/commonTest/kotlin/io/konform/validation/ReadmeExampleTest.kt
+++ b/src/commonTest/kotlin/io/konform/validation/ReadmeExampleTest.kt
@@ -54,7 +54,7 @@ class ReadmeExampleTest {
             Event::organizer {
                 // even though the email is nullable you can force it to be set in the validation
                 Person::email required {
-                    pattern("\\w+@bigcorp.com") hint "Organizers must have a BigCorp email address"
+                    pattern("\\w+@bigcorp.com") hint { _, _ -> "Organizers must have a BigCorp email address" }
                 }
             }
 
@@ -69,17 +69,17 @@ class ReadmeExampleTest {
                     minLength(2)
                 }
                 Person::age {
-                    minimum(18) hint "Attendees must be 18 years or older"
+                    minimum(18) hint StringHintBuilder("Attendees must be 18 years or older")
                 }
                 // Email is optional but if it is set it must be valid
                 Person::email ifPresent {
-                    pattern("\\w+@\\w+\\.\\w+") hint "Please provide a valid email address (optional)"
+                    pattern("\\w+@\\w+\\.\\w+") hint StringHintBuilder("Please provide a valid email address (optional)")
                 }
             }
 
             // validation on the ticketPrices Map as a whole
             Event::ticketPrices {
-                minItems(1) hint "Provide at least one ticket price"
+                minItems(1) hint StringHintBuilder("Provide at least one ticket price")
             }
 
             // validations for the individual entries

--- a/src/commonTest/kotlin/io/konform/validation/ReadmeExampleTest.kt
+++ b/src/commonTest/kotlin/io/konform/validation/ReadmeExampleTest.kt
@@ -53,7 +53,7 @@ class ReadmeExampleTest {
         val validateEvent = Validation<Event> {
             Event::organizer {
                 // even though the email is nullable you can force it to be set in the validation
-                Person::email required {
+                Person::email required with {
                     pattern("\\w+@bigcorp.com") hint { _, _ -> "Organizers must have a BigCorp email address" }
                 }
             }

--- a/src/commonTest/kotlin/io/konform/validation/ReadmeExampleTest.kt
+++ b/src/commonTest/kotlin/io/konform/validation/ReadmeExampleTest.kt
@@ -54,7 +54,7 @@ class ReadmeExampleTest {
             Event::organizer {
                 // even though the email is nullable you can force it to be set in the validation
                 Person::email required with {
-                    pattern("\\w+@bigcorp.com") hint { _, _ -> "Organizers must have a BigCorp email address" }
+                    pattern("\\w+@bigcorp.com") hint "Organizers must have a BigCorp email address"
                 }
             }
 
@@ -69,17 +69,17 @@ class ReadmeExampleTest {
                     minLength(2)
                 }
                 Person::age {
-                    minimum(18) hint stringHint("Attendees must be 18 years or older")
+                    minimum(18) hint "Attendees must be 18 years or older"
                 }
                 // Email is optional but if it is set it must be valid
                 Person::email ifPresent {
-                    pattern("\\w+@\\w+\\.\\w+") hint stringHint("Please provide a valid email address (optional)")
+                    pattern("\\w+@\\w+\\.\\w+") hint "Please provide a valid email address (optional)"
                 }
             }
 
             // validation on the ticketPrices Map as a whole
             Event::ticketPrices {
-                minItems(1) hint stringHint("Provide at least one ticket price")
+                minItems(1) hint "Provide at least one ticket price"
             }
 
             // validations for the individual entries

--- a/src/commonTest/kotlin/io/konform/validation/TestHelpers.kt
+++ b/src/commonTest/kotlin/io/konform/validation/TestHelpers.kt
@@ -1,5 +1,5 @@
 package io.konform.validation
 
-fun <T> countFieldsWithErrors(validationResult: ValidationResult<T>) = (validationResult as Invalid).internalErrors.size
-fun countErrors(validationResult: ValidationResult<*>, vararg properties: Any) = validationResult.get(*properties)?.size
+fun <E, T> countFieldsWithErrors(validationResult: ValidationResult<E, T>) = (validationResult as Invalid).internalErrors.size
+fun countErrors(validationResult: ValidationResult<*, *>, vararg properties: Any) = validationResult.get(*properties)?.size
     ?: 0

--- a/src/commonTest/kotlin/io/konform/validation/ValidationBuilderTest.kt
+++ b/src/commonTest/kotlin/io/konform/validation/ValidationBuilderTest.kt
@@ -8,16 +8,16 @@ import kotlin.test.assertTrue
 class ValidationBuilderTest {
 
     // Some example constraints for Testing
-    fun ValidationBuilder<String>.minLength(minValue: Int) =
-        addConstraint("must have at least {0} characters", minValue.toString()) { it.length >= minValue }
+    fun ValidationBuilder<Unit, String>.minLength(minValue: Int) =
+        addSimpleConstraint("must have at least {0} characters", minValue.toString()) { it.length >= minValue }
 
-    fun ValidationBuilder<String>.maxLength(minValue: Int) =
-        addConstraint("must have at most {0} characters", minValue.toString()) { it.length <= minValue }
+    fun ValidationBuilder<Unit, String>.maxLength(minValue: Int) =
+        addSimpleConstraint("must have at most {0} characters", minValue.toString()) { it.length <= minValue }
 
-    fun ValidationBuilder<String>.matches(regex: Regex) =
-        addConstraint("must have correct format") { it.contains(regex) }
+    fun ValidationBuilder<Unit, String>.matches(regex: Regex) =
+        addSimpleConstraint("must have correct format") { it.contains(regex) }
 
-    fun ValidationBuilder<String>.containsANumber() =
+    fun ValidationBuilder<Unit, String>.containsANumber() =
         matches("[0-9]".toRegex()) hint "must have at least one number"
 
     @Test
@@ -30,6 +30,15 @@ class ValidationBuilderTest {
 
         Register(password = "a").let { assertEquals(Valid(it), oneValidation(it)) }
         Register(password = "").let { assertEquals(1, countErrors(oneValidation(it), Register::password)) }
+    }
+
+    @Test
+    fun singleValidationWithContext() {
+        val validation = Validation<Set<String>, String> {
+            addConstraint("This value is not allowed!") { context, value -> context.contains(value) }
+        }
+        "a".let { assertEquals(Valid(it), validation(setOf("a", "b"), it)) }
+        "c".let { assertEquals(1, countErrors(validation(setOf("a", "b"), it))) }
     }
 
     @Test

--- a/src/commonTest/kotlin/io/konform/validation/ValidationBuilderTest.kt
+++ b/src/commonTest/kotlin/io/konform/validation/ValidationBuilderTest.kt
@@ -9,13 +9,13 @@ class ValidationBuilderTest {
 
     // Some example constraints for Testing
     fun ValidationBuilder<Unit, String>.minLength(minValue: Int) =
-        addSimpleConstraint("must have at least {0} characters", minValue.toString()) { it.length >= minValue }
+        addConstraint("must have at least {0} characters", minValue.toString()) { it.length >= minValue }
 
     fun ValidationBuilder<Unit, String>.maxLength(minValue: Int) =
-        addSimpleConstraint("must have at most {0} characters", minValue.toString()) { it.length <= minValue }
+        addConstraint("must have at most {0} characters", minValue.toString()) { it.length <= minValue }
 
     fun ValidationBuilder<Unit, String>.matches(regex: Regex) =
-        addSimpleConstraint("must have correct format") { it.contains(regex) }
+        addConstraint("must have correct format") { it.contains(regex) }
 
     fun ValidationBuilder<Unit, String>.containsANumber() =
         matches("[0-9]".toRegex()) hint "must have at least one number"
@@ -35,7 +35,7 @@ class ValidationBuilderTest {
     @Test
     fun singleValidationWithContext() {
         val validation = Validation<Set<String>, String> {
-            addConstraint("This value is not allowed!") { context, value -> context.contains(value) }
+            addConstraint("This value is not allowed!") { value -> this.contains(value) }
         }
         "a".let { assertEquals(Valid(it), validation(setOf("a", "b"), it)) }
         "c".let { assertEquals(1, countErrors(validation(setOf("a", "b"), it))) }

--- a/src/commonTest/kotlin/io/konform/validation/ValidationBuilderTest.kt
+++ b/src/commonTest/kotlin/io/konform/validation/ValidationBuilderTest.kt
@@ -112,7 +112,7 @@ class ValidationBuilderTest {
     @Test
     fun validatingRequiredFields() {
         val nullableFieldValidation = Validation<Register> {
-            Register::referredBy required {
+            Register::referredBy required with(stringHintBuilder("is required")) {
                 matches(".+@.+".toRegex())
             }
         }

--- a/src/commonTest/kotlin/io/konform/validation/ValidationBuilderTest.kt
+++ b/src/commonTest/kotlin/io/konform/validation/ValidationBuilderTest.kt
@@ -10,16 +10,16 @@ class ValidationBuilderTest {
 
     // Some example constraints for Testing
     fun ValidationBuilder<Unit, String, String>.minLength(minValue: Int) =
-        addConstraint(StringHintBuilder("must have at least {0} characters"), minValue) { it.length >= minValue }
+        addConstraint(stringHintBuilder("must have at least {0} characters"), minValue) { it.length >= minValue }
 
     fun ValidationBuilder<Unit, String, String>.maxLength(minValue: Int) =
-        addConstraint(StringHintBuilder("must have at most {0} characters"), minValue) { it.length <= minValue }
+        addConstraint(stringHintBuilder("must have at most {0} characters"), minValue) { it.length <= minValue }
 
     fun ValidationBuilder<Unit, String, String>.matches(regex: Regex) =
-        addConstraint(StringHintBuilder("must have correct format")) { it.contains(regex) }
+        addConstraint(stringHintBuilder("must have correct format")) { it.contains(regex) }
 
     fun ValidationBuilder<Unit, String, String>.containsANumber() =
-        matches("[0-9]".toRegex()) hint StringHintBuilder("must have at least one number")
+        matches("[0-9]".toRegex()) hint stringHintBuilder("must have at least one number")
 
     @Test
     fun singleValidation() {
@@ -36,7 +36,7 @@ class ValidationBuilderTest {
     @Test
     fun singleValidationWithContext() {
         val validation = Validation<Set<String>, String> {
-            addConstraint(StringHintBuilder("This value is not allowed!")) { value -> this.contains(value) }
+            addConstraint(stringHintBuilder("This value is not allowed!")) { value -> this.contains(value) }
         }
         "a".let { assertEquals(Valid(it), validation(setOf("a", "b"), it)) }
         "c".let { assertEquals(1, countErrors(validation(setOf("a", "b"), it))) }
@@ -153,18 +153,15 @@ class ValidationBuilderTest {
     @Test
     fun validatingRequiredNullableValues() {
         val nullableRequiredValidation = Validation<String?> {
-            required(StringHintBuilder("Whhoops!")) {
+            required(stringHintBuilder("Whhoops!")) {
                 matches(".+@.+".toRegex())
             }
         }
 
-//        "poweruser@test.com".let { assertEquals(Valid(it), nullableRequiredValidation(it)) }
+        "poweruser@test.com".let { assertEquals(Valid(it), nullableRequiredValidation(it)) }
 
-        val x = nullableRequiredValidation(null)
-        val xc = countErrors(x)
-
-    //        null.let { assertEquals(1, countErrors(nullableRequiredValidation(it))) }
-//        "poweruser@".let { assertEquals(1, countErrors(nullableRequiredValidation(it))) }
+        null.let { assertEquals(1, countErrors(nullableRequiredValidation(it))) }
+        "poweruser@".let { assertEquals(1, countErrors(nullableRequiredValidation(it))) }
     }
 
     @Test
@@ -365,7 +362,7 @@ class ValidationBuilderTest {
         val addressValidation = Validation<AddressContext, Address> {
             Address::address.has.minLength(1)
             Address::country {
-                addConstraint(StringHintBuilder("Country is not allowed")) {
+                addConstraint(stringHintBuilder("Country is not allowed")) {
                     this.validCountries.contains(it)
                 }
             }

--- a/src/commonTest/kotlin/io/konform/validation/ValidationBuilderTest.kt
+++ b/src/commonTest/kotlin/io/konform/validation/ValidationBuilderTest.kt
@@ -343,7 +343,9 @@ class ValidationBuilderTest {
     @Test
     fun composeValidations() {
         val addressValidation = Validation<Address> {
-            Address::address.has.minLength(1)
+            Address::address {
+                minLength(1)
+            }
         }
 
         val validation = Validation<Register> {
@@ -366,25 +368,38 @@ class ValidationBuilderTest {
             }
         }
 
-        val validation = Validation<Context, Register> {
+        val validation = Validation<RegisterContext, Register> {
             Register::home ifPresent {
-                run(addressValidation, Context::subContext)
+                run(addressValidation, RegisterContext::subContext)
             }
         }
 
-        assertEquals(1, countFieldsWithErrors(validation(Context(), Register(home = Address()))))
+        assertEquals(1, countFieldsWithErrors(validation(RegisterContext(), Register(home = Address()))))
     }
 
     @Test
     fun replacePlaceholderInString() {
         val validation = Validation<Register> {
-            Register::password.has.minLength(8)
+            Register::password { minLength(8) }
         }
         assertTrue(validation(Register(password = ""))[Register::password]!![0].contains("8"))
     }
 
+    @Test
+    fun javaFunction() {
+        val s = StringBuilder("")
+
+        val validation = Validation<StringBuilder> {
+            StringBuilder::toString {
+                minLength(12)
+            }
+        }
+
+        assertEquals(1, countFieldsWithErrors(validation(s)))
+    }
+
     private data class Register(val password: String = "", val email: String = "", val referredBy: String? = null, val home: Address? = null)
     private data class Address(val address: String = "", val country: String = "DE")
-    private data class Context(val subContext: AddressContext = AddressContext())
+    private data class RegisterContext(val subContext: AddressContext = AddressContext())
     private data class AddressContext(val validCountries: Set<String> = setOf("DE", "NL", "BE"))
 }

--- a/src/commonTest/kotlin/io/konform/validation/ValidationBuilderTest.kt
+++ b/src/commonTest/kotlin/io/konform/validation/ValidationBuilderTest.kt
@@ -13,13 +13,13 @@ class ValidationBuilderTest {
 
     // Some example constraints for Testing
     fun ValidationBuilder<Unit, String, String>.minLength(minValue: Int) =
-        addConstraint(stringHint("must have at least {0} characters"), minValue) { it.length >= minValue }
+        addConstraint("must have at least {0} characters", minValue) { it.length >= minValue }
 
     fun ValidationBuilder<Unit, String, String>.maxLength(minValue: Int) =
-        addConstraint(stringHint("must have at most {0} characters"), minValue) { it.length <= minValue }
+        addConstraint("must have at most {0} characters", minValue) { it.length <= minValue }
 
     fun ValidationBuilder<Unit, String, String>.matches(regex: Regex) =
-        addConstraint(stringHint("must have correct format")) { it.contains(regex) }
+        addConstraint("must have correct format") { it.contains(regex) }
 
     fun ValidationBuilder<Unit, String, String>.containsANumber() =
         matches("[0-9]".toRegex()) hint stringHint("must have at least one number")
@@ -39,7 +39,7 @@ class ValidationBuilderTest {
     @Test
     fun singleValidationWithContext() {
         val validation = Validation<Set<String>, String> {
-            addConstraint(stringHint("This value is not allowed!")) { value -> this.contains(value) }
+            addConstraint("This value is not allowed!") { value -> this.contains(value) }
         }
         "a".let { assertEquals(Valid(it), validation(setOf("a", "b"), it)) }
         "c".let { assertEquals(1, countErrors(validation(setOf("a", "b"), it))) }
@@ -381,7 +381,7 @@ class ValidationBuilderTest {
         val addressValidation = Validation<AddressContext, Address> {
             Address::address.has.minLength(1)
             Address::country {
-                addConstraint(stringHint("Country is not allowed")) {
+                addConstraint("Country is not allowed") {
                     this.validCountries.contains(it)
                 }
             }

--- a/src/commonTest/kotlin/io/konform/validation/ValidationResultTest.kt
+++ b/src/commonTest/kotlin/io/konform/validation/ValidationResultTest.kt
@@ -20,7 +20,7 @@ class ValidationResultTest {
                     City::postalCode {
                         minLength(4)
                         maxLength(5)
-                        pattern("\\d{4,5}") hint stringHintBuilder("must be a four or five digit number")
+                        pattern("\\d{4,5}") hint stringHint("must be a four or five digit number")
                     }
                 }
             }

--- a/src/commonTest/kotlin/io/konform/validation/ValidationResultTest.kt
+++ b/src/commonTest/kotlin/io/konform/validation/ValidationResultTest.kt
@@ -20,7 +20,7 @@ class ValidationResultTest {
                     City::postalCode {
                         minLength(4)
                         maxLength(5)
-                        pattern("\\d{4,5}") hint ("must be a four or five digit number")
+                        pattern("\\d{4,5}") hint StringHintBuilder("must be a four or five digit number")
                     }
                 }
             }

--- a/src/commonTest/kotlin/io/konform/validation/ValidationResultTest.kt
+++ b/src/commonTest/kotlin/io/konform/validation/ValidationResultTest.kt
@@ -20,7 +20,7 @@ class ValidationResultTest {
                     City::postalCode {
                         minLength(4)
                         maxLength(5)
-                        pattern("\\d{4,5}") hint StringHintBuilder("must be a four or five digit number")
+                        pattern("\\d{4,5}") hint stringHintBuilder("must be a four or five digit number")
                     }
                 }
             }

--- a/src/jvmTest/java/io/konform/validation/TestSubject.java
+++ b/src/jvmTest/java/io/konform/validation/TestSubject.java
@@ -1,0 +1,44 @@
+package io.konform.validation;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class TestSubject {
+
+    public TestSubject() {
+        this("logic will get you from A to Z imagination will get you everywhere");
+    }
+
+    public TestSubject(String string) {
+        this.array = string.split(" ");
+    }
+
+    private final String[] array;
+
+    public String[] stringArray() {
+        return array;
+    }
+
+    public Iterable<String> stringIterable() {
+        return Arrays.asList(array);
+    }
+
+    public Map<String, String> stringMap() {
+        return Arrays.stream(array)
+                .collect(Collectors.toMap(s -> s, s -> s, (s1, s2) -> s1));
+    }
+
+    @Nullable
+    public String nullString() {
+        return null;
+    }
+
+    @Nullable
+    public String notNullString() {
+        return "bla";
+    }
+
+}

--- a/src/jvmTest/kotlin/io/konform/validation/ValidationBuilderJavaTest.kt
+++ b/src/jvmTest/kotlin/io/konform/validation/ValidationBuilderJavaTest.kt
@@ -1,0 +1,81 @@
+package io.konform.validation
+
+import io.konform.validation.jsonschema.maxLength
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ValidationBuilderJavaTest {
+
+    @Test
+    fun validateArrays() {
+        val validation = Validation<TestSubject> {
+            TestSubject::stringArray onEach {
+                maxLength(6)
+            }
+        }
+
+        val result = validation(TestSubject())
+        assertEquals(2, countFieldsWithErrors(result))
+    }
+
+    @Test
+    fun validateIterables() {
+        val validation = Validation<TestSubject> {
+            TestSubject::stringIterable onEach {
+                maxLength(6)
+            }
+        }
+
+        val result = validation(TestSubject())
+        assertEquals(2, countFieldsWithErrors(result))
+    }
+
+    @Test
+    fun validateMaps() {
+        val validation = Validation<TestSubject> {
+            TestSubject::stringMap onEach {
+                Map.Entry<String, String>::value {
+                    maxLength(6)
+                }
+            }
+        }
+
+        val result = validation(TestSubject())
+        assertEquals(2, countFieldsWithErrors(result))
+    }
+
+    @Test
+    fun validateIfPresent() {
+        val validationNull = Validation<TestSubject> {
+            TestSubject::nullString ifPresent {
+                maxLength(2)
+            }
+        }
+        assertTrue(validationNull(TestSubject()) is Valid)
+
+        val validationNonNull = Validation<TestSubject> {
+            TestSubject::notNullString ifPresent {
+                maxLength(2)
+            }
+        }
+        assertEquals(1, countFieldsWithErrors(validationNonNull(TestSubject())))
+    }
+
+    @Test
+    fun validateRequired() {
+        val validationNull = Validation<TestSubject> {
+            TestSubject::nullString required with {
+                maxLength(2)
+            }
+        }
+        assertEquals(1, countFieldsWithErrors(validationNull(TestSubject())))
+
+        val validationNonNull = Validation<TestSubject> {
+            TestSubject::notNullString required with {
+                maxLength(2)
+            }
+        }
+        assertEquals(1, countFieldsWithErrors(validationNonNull(TestSubject())))
+    }
+}


### PR DESCRIPTION
This branch features a list of changes:

### Composition of ValidationBuilders
Currently there is the use of something called `PropKey` to register builders. A `PropKey` contains a `KProperty` and an enum value that explains what type of `Validation` to build. This is not really extensible.

I refactored it to use the Composition pattern. A `ValidationBuilder` can be composed with another that adds an extra level of features.

This was done so that in the future we can add different algebraic operators (think `oneOf`, `lazy`, `eager`, ...)

### Validation on Java functions
It also enables us to create validations on Java functions, because that is abstracted away in a `MappedValidationBuilder` that works allows us to switch from a validation over a type `T` to a type `V` where `(T) -> V`.

### Custom error types
Now the errors are always strings. This is great in 99% of the cases, but in some cases I'd like to add some context to the error. Thus the error type is now generic.

```
enum class Errors { ONE, TWO, THREE }
val validation = Validation<String, Register, Errors> {
    Register::referredBy {
        pattern(staticHint(TWO), ".+@.+")
    }
}
```

The `static` function returns a `HintBuilder`;
```
typealias HintArguments = List<Any>
typealias HintBuilder<C, T, E> = C.(T, HintArguments) -> E
```

*Note* the default error type is `String`, this means that almost no breaking changes were introduced.

### Required as Constraint
It was not possible to add a hint to the `required` validation (since it was no `Constraint`).

The composition pattern makes it easy to rebuild this. So now we can add a hint after a `required` block:

```
SomeObject::optionalValue required with {
    // validate non-null value
} hint stringHint("whoops!")
```

or

```
SomeObject::optionalValue required with(stringHint("whoops!")) {
    // validate non-null value
}
```

*Note* the `with` function creates an object that combines a hint with an `init` function for a `ValidationBuilder`. This is the most noticeable breaking change.

### Improved type safety
To catch type errors on compile time instead runtime, a number of functions have improved type safety

- maxItems
- minItems
- uniqueItems

### Breaking changes
- Introduction of `with` function for required builder
- Extra type arguments needed when adding extension functions to `ValidationBuilder<A, B, C>`
- addConstraint has different signature
- More?

### README
The readme is updated to reflect the latest changes, but needs some changes to elaborate on:

- Context
- Custom error types

## Extra notes on the changes
I know there are a lot of changes in this branch and understand that it is a lot to process in one go. I also believe that the essence of *Konform* is still intact, proven by the strong backwards compatibility.

Please consider merging this branch.

