### PR TITLE
Make Invalid non-generic

### DIFF
--- a/src/commonMain/kotlin/io/konform/validation/internal/Validation.kt
+++ b/src/commonMain/kotlin/io/konform/validation/internal/Validation.kt
@@ -54,7 +54,7 @@ internal class RequiredPropertyValidation<T, R>(
     override fun validate(value: T): ValidationResult<T> {
         val propertyValue =
             property(value)
-                ?: return Invalid<T>(mapOf(".${property.name}" to listOf("is required")))
+                ?: return Invalid(mapOf(".${property.name}" to listOf("is required")))
         return validation(propertyValue).mapError { ".${property.name}$it" }.map { value }
     }
 }


### PR DESCRIPTION
ValidationResult was already made covariant in #56. This improves upon that by making `Invalid` invariant and extend `ValidationResult<Nothing>`, which is possible since `Invalid` does not hold the result, only the errors.

Additionally, make `map` an inline function which improves performance.