### PR TITLE
Bump release version JVM workflow to 21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,9 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 8
+          # Library is built for JVM 1.8, but we run gradle itself with a newer one because we can
+          # and the publishing plugin requires it
+          java-version: 21
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:


### PR DESCRIPTION
Follow up on #108 . This also bumps the JVM of the release workflow to 21. We still want to built with/against 1.8, but hopefully this satisfies the JVM >= 11 constraint of the publishing plugin we use.