### PR TITLE
change the release CI target to macos-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     name: release
     # First run the normal tests
     needs: [test]
+    # Release on macOS for the macOS build targets
+    # macOS can release the other build targets too but not vice-versa
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     name: release
     # First run the normal tests
     needs: [test]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,14 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          # Test on macOS for the macOS build targets
+          - macos-latest
+    runs-on: ${{matrix.os}}
+    name: Test on ${{matrix.os}}
     steps:
       - uses: actions/checkout@v4
         name: Checkout


### PR DESCRIPTION
Addresses the #118. 

These are the artifacts generated when running `./gradlew  publishToMavenLocal`

| Before | After |
| --- | --- |
| From https://repo1.maven.org/maven2/io/konform/ <br/> <br/> ![344641289-70e1b81b-2559-496a-8f04-9b828796a2a9](https://github.com/konform-kt/konform/assets/19205305/64d201a3-dafe-4668-86e3-054baa511b44) | `./gradlew  publishToMavenLocal` on macos <br/> <br/> ![Screenshot 2024-07-02 at 09 16 55](https://github.com/konform-kt/konform/assets/19205305/c9171ea3-11d0-46f3-bfcb-ea826f961b2f) |




