### PR TITLE
Add github workflow cache for Kotlin native dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
           # and the publishing plugin requires it
           java-version: 21
           cache: 'gradle'
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Restore caches
         uses: actions/cache/restore@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,16 @@ jobs:
           # and the publishing plugin requires it
           java-version: 21
           cache: 'gradle'
+      - name: Restore caches
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.konan
+            ~/.npm
+            ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: build-${{ runner.os }}-${{ hashFiles('build.gradle.kts', '**/gradle-wrapper.properties', 'settings.gradle.kts', 'kotlin-js-store/yarn.lock') }}
+          # There should've been at least one test run that creates the cache at this point
+          fail-on-cache-miss: true
       - name: Get Version
         id: get-version
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,5 +28,19 @@ jobs:
           # and the publishing plugin requires it
           java-version: 21
           cache: 'gradle'
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      - name: Cache Kotlin JS/Native dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.konan
+            ~/.npm
+            ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: build-${{ runner.os }}-${{ hashFiles('build.gradle.kts', '**/gradle-wrapper.properties', 'settings.gradle.kts', 'kotlin-js-store/yarn.lock') }}
+          restore-keys: |
+            build-${{ runner.os }}-${{ hashFiles('build.gradle.kts') }}
+            build-${{ runner.os }}-
       - name: Assemble & Test project
         run: ./gradlew build


### PR DESCRIPTION
The Kotlin/JS and Kotlin/Native dependencies weren't cached, which was especially noticable on the macos build #119 introduced since it needs to download the xcode stuff.