### PR TITLE
Fix release process for macOS runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - dhoepelman/test-release
     tags:
       - 'v[0-9].[0-9].[0-9]'
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - dhoepelman/test-release
     tags:
       - 'v[0-9].[0-9].[0-9]'
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,20 +4,22 @@ on:
     branches:
       - main
     tags:
-      - 'v*'
+      - 'v[0-9].[0-9].[0-9]'
 permissions:
   contents: read
   issues: write
 jobs:
   test:
     uses: ./.github/workflows/test.yml
-  release:
-    name: release
+  create-artifacts:
     # First run the normal tests
     needs: [test]
     # Release on macOS for the macOS build targets
     # macOS can release the other build targets too but not vice-versa
     runs-on: macos-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+      is_snapshot: ${{ steps.get-version.outputs.is_snapshot }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -66,36 +68,28 @@ jobs:
       - name: Publish version '${{ steps.get-version.outputs.version }}' to sonatype & close staging repo
         env:
           CI_VERSION: ${{ steps.get-version.outputs.version }}
-          IS_SNAPSHOT: ${{ steps.get-version.outputs.is_snapshot }}
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           MAVEN_CENTRAL_TOKEN_USER: ${{ secrets.MAVEN_CENTRAL_TOKEN_USER }}
           MAVEN_CENTRAL_TOKEN_PW: ${{ secrets.MAVEN_CENTRAL_TOKEN_PW }}
         run: |
           echo "Publishing version '$CI_VERSION' to sonatype."
-          if [[ $IS_SNAPSHOT == "true" ]]; then
-            ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --info
-          else
-            ./gradlew publishToSonatype closeSonatypeStagingRepository --info
-          fi
+          ./gradlew publishToSonatype closeSonatypeStagingRepository --info
 
-      - uses: trstringer/manual-approval@v1
-        name: "Wait for approval to publish version '${{ steps.get-version.outputs.version }}'"
-        if: ${{ steps.get-version.outputs.is_snapshot == 'false' }}
+  release:
+    needs: [create-artifacts]
+    runs-on: ubuntu-latest
+    environment: ${{needs.create-artifacts.outputs.is_snapshot=='false' && 'maven-central-release' || 'maven-central-snapshot'}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
-          secret: ${{ github.TOKEN }}
-          approvers: dhoepelman,nlochschmidt
-          minimum-approvals: 1
-          issue-title: "Release version '${{ steps.get-version.outputs.version }}'"
-          issue-body: "Please approve or deny the release of version '${{ steps.get-version.outputs.version }}'."
-          # Default included: "approve", "approved", "lgtm", "yes"
-          additional-approved-words: ''
-          # Default included: "deny", "denied", "no"
-          additional-denied-words: ''
+          distribution: temurin
+          java-version: 21
+          cache: 'gradle'
 
-      - name: "Release version '${{ steps.get-version.outputs.version }}'"
-        if: ${{ steps.get-version.outputs.is_snapshot == 'false' }}
+      - name: "Release version '${{needs.create-artifacts.outputs.version}}'"
         env:
-          CI_VERSION: ${{ steps.get-version.outputs.version }}
+          CI_VERSION: ${{needs.create-artifacts.outputs.version}}
           MAVEN_CENTRAL_TOKEN_USER: ${{ secrets.MAVEN_CENTRAL_TOKEN_USER }}
           MAVEN_CENTRAL_TOKEN_PW: ${{ secrets.MAVEN_CENTRAL_TOKEN_PW }}
         run: ./gradlew findSonatypeStagingRepository releaseSonatypeStagingRepository --info

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation("io.konform:konform:0.6.0")
+                implementation("io.konform:konform:0.6.1")
             }
         }
     }
@@ -27,7 +27,7 @@ For jvm-only projects add:
 
 ```
 dependencies {
-    implementation("io.konform:konform-jvm:0.6.0")
+    implementation("io.konform:konform-jvm:0.6.1")
 }
 ```
 


### PR DESCRIPTION
#119 broke the release step because the manual approval action was not supported.

Trying again with github deployments instead. Can bring back the action if neccessary since this allows using a linux runner.