### PR TITLE
Use libs.versions.toml

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,18 @@
+[versions]
+kotest = "5.9.1"
+kotlin = "2.0.20"
+ktlint = "1.3.1"
+
+[libraries]
+kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
+kotest-framework-datatest = { module = "io.kotest:kotest-framework-datatest", version.ref = "kotest" }
+kotest-framework-engine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
+kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
+# Not actually used as dependency, but hopefully this causes dependabot to pick up on ktlint versions
+ktlint = { module = "com.pinterest:ktlint-bom", version.ref = "ktlint" }
+
+[plugins]
+kotest-multiplatform = { id = "io.kotest.multiplatform", version.ref = "kotest" }
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "12.1.1" }
+nexuspublish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }


### PR DESCRIPTION
Started out as a way to introduce kotest which didn't quite work out yet, but libs.versions.toml is still nice