### PR TITLE
Allow customizing hint in required

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ val validateEvent = Validation<Event> {
     Event::organizer {
         // even though the email is nullable you can force it to be set in the validation
         Person::email required {
+            // Optionally set a hint, default hint is "is required"
+            hint = "Email address must be given"
             pattern(".+@bigcorp.com") hint "Organizers must have a BigCorp email address"
         }
     }

--- a/api/konform.api
+++ b/api/konform.api
@@ -82,7 +82,7 @@ public class io/konform/validation/ValidationBuilder {
 	public fun <init> ()V
 	public final fun addConstraint (Ljava/lang/String;[Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/konform/validation/Constraint;
 	public final fun applyConstraint (Lio/konform/validation/Constraint;)Lio/konform/validation/Constraint;
-	public final fun build ()Lio/konform/validation/Validation;
+	public fun build ()Lio/konform/validation/Validation;
 	public final fun constrain (Ljava/lang/String;Lio/konform/validation/path/ValidationPath;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lio/konform/validation/Constraint;
 	public static synthetic fun constrain$default (Lio/konform/validation/ValidationBuilder;Ljava/lang/String;Lio/konform/validation/path/ValidationPath;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/konform/validation/Constraint;
 	public final fun dynamic (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
@@ -158,7 +158,8 @@ public final class io/konform/validation/ValidationErrorKt {
 public final class io/konform/validation/ValidationKt {
 	public static final fun flatten (Ljava/util/List;)Lio/konform/validation/Validation;
 	public static final fun ifPresent (Lio/konform/validation/Validation;)Lio/konform/validation/Validation;
-	public static final fun required (Lio/konform/validation/Validation;)Lio/konform/validation/Validation;
+	public static final fun required (Lio/konform/validation/Validation;Ljava/lang/String;)Lio/konform/validation/Validation;
+	public static synthetic fun required$default (Lio/konform/validation/Validation;Ljava/lang/String;ILjava/lang/Object;)Lio/konform/validation/Validation;
 }
 
 public abstract class io/konform/validation/ValidationResult {
@@ -177,6 +178,19 @@ public final class io/konform/validation/ValidationResultKt {
 	public static final fun flattenNotEmpty (Ljava/util/List;)Lio/konform/validation/Invalid;
 	public static final fun flattenOrValid (Ljava/util/List;Ljava/lang/Object;)Lio/konform/validation/ValidationResult;
 	public static final fun flattenOrValidInvalidList (Ljava/util/List;Ljava/lang/Object;)Lio/konform/validation/ValidationResult;
+}
+
+public final class io/konform/validation/builders/RequiredValidationBuilder : io/konform/validation/ValidationBuilder {
+	public static final field Companion Lio/konform/validation/builders/RequiredValidationBuilder$Companion;
+	public fun <init> ()V
+	public synthetic fun build ()Lio/konform/validation/Validation;
+	public fun build ()Lio/konform/validation/types/RequireNotNullValidation;
+	public final fun getHint ()Ljava/lang/String;
+	public final fun setHint (Ljava/lang/String;)V
+}
+
+public final class io/konform/validation/builders/RequiredValidationBuilder$Companion {
+	public final fun buildWithNew (Lkotlin/jvm/functions/Function1;)Lio/konform/validation/types/RequireNotNullValidation;
 }
 
 public final class io/konform/validation/constraints/EnumConstraintsKt {
@@ -412,6 +426,14 @@ public final class io/konform/validation/types/PrependPathValidation : io/konfor
 	public fun prependPath (Lio/konform/validation/path/PathSegment;)Lio/konform/validation/Validation;
 	public fun prependPath (Lio/konform/validation/path/ValidationPath;)Lio/konform/validation/Validation;
 	public fun toString ()Ljava/lang/String;
+	public fun validate (Ljava/lang/Object;)Lio/konform/validation/ValidationResult;
+}
+
+public final class io/konform/validation/types/RequireNotNullValidation : io/konform/validation/Validation {
+	public fun <init> (Ljava/lang/String;Lio/konform/validation/Validation;)V
+	public fun invoke (Ljava/lang/Object;)Lio/konform/validation/ValidationResult;
+	public fun prependPath (Lio/konform/validation/path/PathSegment;)Lio/konform/validation/Validation;
+	public fun prependPath (Lio/konform/validation/path/ValidationPath;)Lio/konform/validation/Validation;
 	public fun validate (Ljava/lang/Object;)Lio/konform/validation/ValidationResult;
 }
 

--- a/src/commonMain/kotlin/io/konform/validation/Validation.kt
+++ b/src/commonMain/kotlin/io/konform/validation/Validation.kt
@@ -3,8 +3,10 @@ package io.konform.validation
 import io.konform.validation.path.PathSegment
 import io.konform.validation.path.ValidationPath
 import io.konform.validation.types.EmptyValidation
-import io.konform.validation.types.NullableValidation
+import io.konform.validation.types.IfNotNullValidation
 import io.konform.validation.types.PrependPathValidation
+import io.konform.validation.types.RequireNotNullValidation
+import io.konform.validation.types.RequireNotNullValidation.Companion.DEFAULT_REQUIRED_HINT
 import io.konform.validation.types.ValidateAll
 
 public interface Validation<in T> {
@@ -30,7 +32,7 @@ public fun <T> List<Validation<T>>.flatten(): Validation<T> =
     }
 
 /** Run a validation only if the actual value is not-null. */
-public fun <T : Any> Validation<T>.ifPresent(): Validation<T?> = NullableValidation(required = false, validation = this)
+public fun <T : Any> Validation<T>.ifPresent(): Validation<T?> = IfNotNullValidation(this)
 
 /** Require a nullable value to actually be present. */
-public fun <T : Any> Validation<T>.required(): Validation<T?> = NullableValidation(required = true, validation = this)
+public fun <T : Any> Validation<T>.required(hint: String = DEFAULT_REQUIRED_HINT): Validation<T?> = RequireNotNullValidation(hint, this)

--- a/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/ValidationBuilder.kt
@@ -1,6 +1,7 @@
 package io.konform.validation
 
 import io.konform.validation.ValidationBuilder.Companion.buildWithNew
+import io.konform.validation.builders.RequiredValidationBuilder
 import io.konform.validation.helpers.prepend
 import io.konform.validation.path.FuncRef
 import io.konform.validation.path.PathSegment
@@ -27,7 +28,7 @@ public open class ValidationBuilder<T> {
     protected val constraints: MutableList<Constraint<T>> = mutableListOf()
     protected val subValidations: MutableList<Validation<T>> = mutableListOf()
 
-    public fun build(): Validation<T> =
+    public open fun build(): Validation<T> =
         subValidations
             .let {
                 if (constraints.isNotEmpty()) {
@@ -118,13 +119,13 @@ public open class ValidationBuilder<T> {
 
     public operator fun <R> KFunction1<T, R>.invoke(init: ValidationBuilder<R>.() -> Unit): Unit = validate(this, this, init)
 
-    public infix fun <R> KProperty1<T, R?>.ifPresent(init: ValidationBuilder<R>.() -> Unit): Unit = ifPresent(this, this, init)
+    public infix fun <R : Any> KProperty1<T, R?>.ifPresent(init: ValidationBuilder<R>.() -> Unit): Unit = ifPresent(this, this, init)
 
-    public infix fun <R> KFunction1<T, R?>.ifPresent(init: ValidationBuilder<R>.() -> Unit): Unit = ifPresent(this, this, init)
+    public infix fun <R : Any> KFunction1<T, R?>.ifPresent(init: ValidationBuilder<R>.() -> Unit): Unit = ifPresent(this, this, init)
 
-    public infix fun <R> KProperty1<T, R?>.required(init: ValidationBuilder<R>.() -> Unit): Unit = required(this, this, init)
+    public infix fun <R : Any> KProperty1<T, R?>.required(init: RequiredValidationBuilder<R>.() -> Unit): Unit = required(this, this, init)
 
-    public infix fun <R> KFunction1<T, R?>.required(init: ValidationBuilder<R>.() -> Unit): Unit = required(this, this, init)
+    public infix fun <R : Any> KFunction1<T, R?>.required(init: ValidationBuilder<R>.() -> Unit): Unit = required(this, this, init)
 
     public infix fun <R> KProperty1<T, R>.dynamic(init: ValidationBuilder<R>.(T) -> Unit): Unit = dynamic(this, this, init)
 
@@ -167,11 +168,11 @@ public open class ValidationBuilder<T> {
      * @param path The [PathSegment] or [ValidationPath] of the validation.
      *   is [Any] for backwards compatibility and ease of use, see [ValidationPath.of].
      */
-    public fun <R> required(
+    public fun <R : Any> required(
         path: Any,
         f: (T) -> R?,
-        init: ValidationBuilder<R>.() -> Unit,
-    ): Unit = run(CallableValidation(path, f, buildWithNew(init).required()))
+        init: RequiredValidationBuilder<R>.() -> Unit,
+    ): Unit = run(CallableValidation(path, f, RequiredValidationBuilder.buildWithNew(init)))
 
     public fun run(validation: Validation<T>) {
         subValidations.add(validation)

--- a/src/commonMain/kotlin/io/konform/validation/builders/RequiredValidationBuilder.kt
+++ b/src/commonMain/kotlin/io/konform/validation/builders/RequiredValidationBuilder.kt
@@ -1,0 +1,32 @@
+package io.konform.validation.builders
+
+import io.konform.validation.ValidationBuilder
+import io.konform.validation.types.RequireNotNullValidation
+import io.konform.validation.types.RequireNotNullValidation.Companion.DEFAULT_REQUIRED_HINT
+
+/**
+ * A [ValidationBuilder] for [RequireNotNullValidation].
+ * Allows setting the hint for the validation when the value is null with the following syntax:
+ * ```
+ * User::name required {
+ *   hint = "Please fill in your name"
+ *   // other validations on name as normal
+ * }
+ * ```
+ */
+public class RequiredValidationBuilder<T : Any> : ValidationBuilder<T>() {
+    public var hint: String = DEFAULT_REQUIRED_HINT
+
+    override fun build(): RequireNotNullValidation<T> {
+        val subValidation = super.build()
+        return RequireNotNullValidation(hint, subValidation)
+    }
+
+    public companion object {
+        public inline fun <T : Any> buildWithNew(block: RequiredValidationBuilder<T>.() -> Unit): RequireNotNullValidation<T> {
+            val builder = RequiredValidationBuilder<T>()
+            block(builder)
+            return builder.build()
+        }
+    }
+}

--- a/src/commonMain/kotlin/io/konform/validation/types/NullableValidation.kt
+++ b/src/commonMain/kotlin/io/konform/validation/types/NullableValidation.kt
@@ -4,24 +4,33 @@ import io.konform.validation.Invalid
 import io.konform.validation.Valid
 import io.konform.validation.Validation
 import io.konform.validation.ValidationResult
-import io.konform.validation.path.PathSegment
 import io.konform.validation.path.ValidationPath
 
-internal class NullableValidation<T : Any>(
-    private val pathSegment: PathSegment? = null,
-    private val required: Boolean,
+internal class IfNotNullValidation<T : Any>(
     private val validation: Validation<T>,
 ) : Validation<T?> {
     override fun validate(value: T?): ValidationResult<T?> =
         if (value == null) {
-            if (required) {
-                val path = ValidationPath(listOfNotNull(pathSegment))
-                Invalid.of(path, "is required")
-            } else {
-                Valid(value)
-            }
+            Valid(value)
         } else {
             // Don't prepend path here since we expect the validation to contain the complete path
             validation(value)
         }
+}
+
+public class RequireNotNullValidation<T : Any>(
+    private val hint: String,
+    private val validation: Validation<T>,
+) : Validation<T?> {
+    override fun validate(value: T?): ValidationResult<T?> =
+        if (value == null) {
+            Invalid.of(ValidationPath.EMPTY, hint)
+        } else {
+            // Don't prepend path here since we expect the validation to contain the complete path
+            validation(value)
+        }
+
+    internal companion object {
+        internal const val DEFAULT_REQUIRED_HINT = "is required"
+    }
 }

--- a/src/commonTest/kotlin/io/konform/validation/ValidationBuilderTest.kt
+++ b/src/commonTest/kotlin/io/konform/validation/ValidationBuilderTest.kt
@@ -112,21 +112,6 @@ class ValidationBuilderTest {
     }
 
     @Test
-    fun validatingRequiredFields() {
-        val nullableFieldValidation =
-            Validation<Register> {
-                Register::referredBy required {
-                    pattern(".+@.+".toRegex()).hint("must have correct format")
-                }
-            }
-
-        Register(referredBy = "poweruser@test.com").let { assertEquals(Valid(it), nullableFieldValidation(it)) }
-
-        Register(referredBy = null).let { assertEquals(1, countErrors(nullableFieldValidation(it), Register::referredBy)) }
-        Register(referredBy = "poweruser@").let { assertEquals(1, countErrors(nullableFieldValidation(it), Register::referredBy)) }
-    }
-
-    @Test
     fun validatingNestedTypesDirectly() {
         val nestedTypeValidation =
             Validation<Register> {
@@ -153,21 +138,6 @@ class ValidationBuilderTest {
         null.let { assertEquals(Valid(it), nullableTypeValidation(it)) }
         "poweruser@test.com".let { assertEquals(Valid(it), nullableTypeValidation(it)) }
         "poweruser@".let { assertEquals(1, countErrors(nullableTypeValidation(it))) }
-    }
-
-    @Test
-    fun validatingRequiredNullableValues() {
-        val nullableRequiredValidation =
-            Validation<String?> {
-                required {
-                    pattern(".+@.+".toRegex()).hint("must have correct format")
-                }
-            }
-
-        "poweruser@test.com".let { assertEquals(Valid(it), nullableRequiredValidation(it)) }
-
-        null.let { assertEquals(1, countErrors(nullableRequiredValidation(it))) }
-        "poweruser@".let { assertEquals(1, countErrors(nullableRequiredValidation(it))) }
     }
 
     @Test

--- a/src/commonTest/kotlin/io/konform/validation/validationbuilder/RequiredTest.kt
+++ b/src/commonTest/kotlin/io/konform/validation/validationbuilder/RequiredTest.kt
@@ -1,0 +1,80 @@
+package io.konform.validation.validationbuilder
+
+import io.konform.validation.Valid
+import io.konform.validation.Validation
+import io.konform.validation.ValidationError
+import io.konform.validation.constraints.minLength
+import io.konform.validation.constraints.pattern
+import io.konform.validation.countErrors
+import io.konform.validation.required
+import io.kotest.assertions.konform.shouldBeInvalid
+import io.kotest.assertions.konform.shouldBeValid
+import io.kotest.assertions.konform.shouldContainOnlyError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RequiredTest {
+    @Test
+    fun validatingRequiredFields() {
+        val nullableFieldValidation =
+            Validation<Register> {
+                Register::referredBy required {
+                    pattern(".+@.+".toRegex()).hint("must have correct format")
+                }
+            }
+
+        Register("poweruser@test.com").let { assertEquals(Valid(it), nullableFieldValidation(it)) }
+
+        Register(null).let { assertEquals(1, countErrors(nullableFieldValidation(it), Register::referredBy)) }
+        Register("poweruser@").let { assertEquals(1, countErrors(nullableFieldValidation(it), Register::referredBy)) }
+    }
+
+    @Test
+    fun setRequiredHint() {
+        val validation =
+            Validation<Register> {
+                Register::referredBy required {
+                    hint = "a referral is required"
+                }
+            }
+
+        (validation shouldBeInvalid Register(null)) shouldContainOnlyError
+            ValidationError.of(Register::referredBy, "a referral is required")
+    }
+
+    @Test
+    fun validatingRequiredNullableValues() {
+        val nullableRequiredValidation =
+            Validation<String?> {
+                required {
+                    pattern(".+@.+".toRegex()).hint("must have correct format")
+                }
+            }
+
+        "poweruser@test.com".let { assertEquals(Valid(it), nullableRequiredValidation(it)) }
+
+        null.let { assertEquals(1, countErrors(nullableRequiredValidation(it))) }
+        "poweruser@".let { assertEquals(1, countErrors(nullableRequiredValidation(it))) }
+    }
+
+    @Test
+    fun requiredFunction() {
+        val validation =
+            Validation<String?> {
+                required("trimmed", { it?.trim() }) {
+                    hint = "string must be present"
+                    minLength(2)
+                }
+            }
+
+        validation shouldBeValid "abc"
+        (validation shouldBeInvalid null) shouldContainOnlyError
+            ValidationError.of("trimmed", "string must be present")
+        (validation shouldBeInvalid "  a") shouldContainOnlyError
+            ValidationError.of("trimmed", "must have at least 2 characters")
+    }
+
+    private data class Register(
+        val referredBy: String? = null,
+    )
+}


### PR DESCRIPTION
Fixes https://github.com/konform-kt/konform/issues/36

Th syntax is (also seen in README is)

```kotlin
Class:prop required {
  hint = "..."
}
```

this was not my preferred syntax, but it was one of the only viable ones.

Alternative 2:
```kotlin
Class:prop required(hint = "...") { }
```
is not valid kotlin syntax, infix functions cannot have extra parameters

Alternative 3:
```kotlin
Class:prop required { } hint("...")
```

would require changing the return type of these validationbuilder from `Unit` to something else, most likely `Validation`, and adding `hint` to ever validation, which I don't want. I couldn't think of a good alternative for returning.