### PR TITLE
Release from CI for version numbers of 2+ characters

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     tags:
-      - 'v[0-9].[0-9].[0-9]'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 permissions:
   contents: read
   issues: write


### PR DESCRIPTION
Encountered when 0.10.0 didn't auto-release