### PR TITLE
Upgrade to Kotlin 2.1.20 and Java Target 11 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          # Library is built for JVM 1.8, but we run gradle itself with a newer one because we can
-          # and the publishing plugin requires it
-          java-version: 21
+          java-version: 11
           cache: 'gradle'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,21 +1,17 @@
 import org.gradle.internal.extensions.stdlib.capitalized
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.testing.internal.KotlinTestReport
 
 val projectName = "konform"
 val projectGroup = "io.konform"
 val projectDesc = "Konform: Portable validations for Kotlin"
-val projectHost = "github"
-val projectOrg = "konform-kt"
 val projectLicense = "MIT"
 val projectLicenseUrl = "https://opensource.org/licenses/MIT"
 val projectScmUrl = "https://github.com/konform-kt/konform.git"
 val projectInceptionYear = 2018
 
 val kotlinApiTarget = "1.9"
-val jvm = JvmTarget.JVM_1_8
+val jvmTarget = JavaLanguageVersion.of(11)
 
 /** The "CI" env var is a quasi-standard way to indicate that we're running on CI. */
 val onCI: Boolean = System.getenv("CI") == "true"
@@ -56,14 +52,10 @@ kotlin {
     androidNativeArm64()
     androidNativeX86()
     androidNativeX64()
-    jvm {
-        @OptIn(ExperimentalKotlinGradlePluginApi::class)
-        compilerOptions {
-            // note lang toolchain cannot be used here
-            // because gradle no longer supports running on java 8
-            jvmTarget = jvm
-        }
+    jvmToolchain {
+        languageVersion.set(jvmTarget)
     }
+    jvm {}
     js(IR) {
         browser {}
         nodejs {}
@@ -175,6 +167,7 @@ publishing {
             pom {
                 name = projectName
                 description = projectDesc
+                inceptionYear = projectInceptionYear.toString()
                 url = "https://github.com/konform-kt/konform"
                 licenses {
                     license {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotest = "5.9.1"
-kotlin = "2.1.10"
+kotlin = "2.1.20"
 ktlint = "1.5.0"
 
 [libraries]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,5 @@
 rootProject.name = "konform"
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version ("0.9.0")
+}


### PR DESCRIPTION
Java 1.8 is getting harder to support as some of the build tools no longer support it.
Since Android supports 11 since 2022, dropping 1.8 is starting to get acceptable as support is increasing (Android 11 I believe, currently 82%)

As we don't really need JVM 11 bytecode features I'm happy to reintroduce support if someone provides a PR and the build maintenance overhead is acceptable.