### PR TITLE
Add dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -3,6 +3,9 @@ name: Dependabot Auto-merge
 on:
   pull_request:
     branches: [main]
+  check_run:
+    types: [completed]
+  status: {}
 
 permissions:
   contents: write
@@ -13,8 +16,26 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
+      - name: Auto-approve dependabot PRs
+        if: github.event_name == 'pull_request'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Enable auto-merge for dependabot PRs
+        if: github.event_name == 'pull_request'
         run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  check-failures:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'check_run' && github.event.check_run.conclusion == 'failure' && github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Disable auto-merge on check failure
+        run: gh pr merge --disable-auto "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -3,9 +3,6 @@ name: Dependabot Auto-merge
 on:
   pull_request:
     branches: [main]
-  check_run:
-    types: [completed]
-  status: {}
 
 permissions:
   contents: write
@@ -16,26 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - name: Auto-approve dependabot PRs
-        if: github.event_name == 'pull_request'
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Enable auto-merge for dependabot PRs
-        if: github.event_name == 'pull_request'
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  check-failures:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'check_run' && github.event.check_run.conclusion == 'failure' && github.event.pull_request.user.login == 'dependabot[bot]'
-    steps:
-      - name: Disable auto-merge on check failure
-        run: gh pr merge --disable-auto "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Auto-merge dependabot PRs
+        uses: fastify/github-action-merge-dependabot@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          use-github-auto-merge: true

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,20 @@
+name: Dependabot Auto-merge
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Enable auto-merge for dependabot PRs
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Automatically approve and enable auto-merge for dependabot PRs when status checks pass
- Uses fastify/github-action-merge-dependabot@v3 with GitHub's native auto-merge

## Test plan
- [x] Only triggers for dependabot[bot] PRs
- [x] Leverages GitHub auto-merge for automatic failure handling

🤖 Generated with [Claude Code](https://claude.ai/code)