### PR TITLE
Enable Renovate automerge for minor and patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,11 @@
 {
     "extends": [
         "config:base"
+    ],
+    "packageRules": [
+        {
+            "matchUpdateTypes": ["minor", "patch"],
+            "automerge": true
+        }
     ]
 }


### PR DESCRIPTION
## Summary
- Enable automerge for minor and patch dependency updates in renovate.json
- Uses Renovate's built-in automerge functionality (recommended approach)
- Major updates still require manual review for safety

🤖 Generated with [Claude Code](https://claude.ai/code)