### PR TITLE
Add Cursor rules for PR workflow

### DIFF
--- a/.cursor/rules/api-changes.md
+++ b/.cursor/rules/api-changes.md
@@ -1,0 +1,7 @@
+## API Changes
+
+When making changes to the public API:
+- Always run `./gradlew apiDump` before committing
+- This updates the API dump files in the `api/` directory
+- Include the updated API dump files in your commit
+- This ensures binary compatibility tracking is maintained

--- a/.cursor/rules/pull-requests.md
+++ b/.cursor/rules/pull-requests.md
@@ -1,0 +1,14 @@
+## Pull Request Requirements
+
+Always use pull requests for changes:
+- Never push directly to main branch
+- Create a PR for all changes, even small ones
+- Use descriptive branch names
+
+## Pull Request Descriptions
+
+Keep PR descriptions compact and to the point:
+- Maximum 2-3 bullet points in summary
+- Avoid verbose explanations or redundant information
+- Focus on what changed and why, not how
+- Use concise language without unnecessary detail

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,7 @@
+## Pull Request Descriptions
+
+Keep PR descriptions compact and to the point:
+- Maximum 2-3 bullet points in summary
+- Avoid verbose explanations or redundant information
+- Focus on what changed and why, not how
+- Use concise language without unnecessary detail

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,7 +1,0 @@
-## Pull Request Descriptions
-
-Keep PR descriptions compact and to the point:
-- Maximum 2-3 bullet points in summary
-- Avoid verbose explanations or redundant information
-- Focus on what changed and why, not how
-- Use concise language without unnecessary detail


### PR DESCRIPTION
## Summary
- Require PRs for all changes to main branch
- Keep PR descriptions compact and focused  
- Use modern .cursor/rules directory structure

🤖 Generated with [Claude Code](https://claude.ai/code)