### PR TITLE
Fix configuration cache compatibility with Sonatype publishing tasks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -223,6 +223,11 @@ nexusPublishing {
         }
     }
 }
+
+// Disable configuration cache for nexus publishing tasks due to incompatibility
+tasks.matching { it.name.contains("Sonatype", ignoreCase = true) }.configureEach {
+    notCompatibleWithConfigurationCache("Nexus publishing plugin tasks are not compatible with configuration cache")
+}
 //endregion
 
 //region IDE configuration


### PR DESCRIPTION
Fixes configuration cache errors by marking Sonatype publishing tasks as incompatible with configuration cache.

## Issue
The nexus-publish-plugin tasks (, etc.) are not compatible with Gradle's configuration cache, causing build failures.

## Solution
Mark these tasks as  so Gradle knows to skip caching for them while still benefiting from configuration cache for other tasks.