### PR TITLE
Replace all internal addConstraint usages with constrain

### DIFF
--- a/src/commonMain/kotlin/io/konform/validation/constraints/AnyConstraints.kt
+++ b/src/commonMain/kotlin/io/konform/validation/constraints/AnyConstraints.kt
@@ -3,5 +3,4 @@ package io.konform.validation.constraints
 import io.konform.validation.Constraint
 import io.konform.validation.ValidationBuilder
 
-public inline fun <reified T> ValidationBuilder<*>.type(): Constraint<*> =
-    addConstraint("must be of type '${T::class.simpleName}'") { it is T }
+public inline fun <reified T> ValidationBuilder<*>.type(): Constraint<*> = constrain("must be of type '${T::class.simpleName}'") { it is T }

--- a/src/commonMain/kotlin/io/konform/validation/constraints/EnumConstraints.kt
+++ b/src/commonMain/kotlin/io/konform/validation/constraints/EnumConstraints.kt
@@ -6,7 +6,7 @@ import io.konform.validation.ValidationBuilder
 /** Restrict a value to a set of allowed values. */
 public fun <T> ValidationBuilder<T>.enum(vararg allowed: T): Constraint<T> {
     val set = allowed.toSet()
-    return addConstraint("must be one of: ${set.joinToString("', '", "'", "'")}") {
+    return constrain("must be one of: ${set.joinToString("', '", "'", "'")}") {
         it in allowed
     }
 }
@@ -14,9 +14,9 @@ public fun <T> ValidationBuilder<T>.enum(vararg allowed: T): Constraint<T> {
 /** Restrict a [String] to the entry names of an [Enum]. */
 public inline fun <reified T : Enum<T>> ValidationBuilder<String>.enum(): Constraint<String> {
     val enumNames = enumValues<T>().mapTo(mutableSetOf()) { it.name }
-    return addConstraint("must be one of: ${enumNames.joinToString("', '", "'", "'")}") {
+    return constrain("must be one of: ${enumNames.joinToString("', '", "'", "'")}") {
         it in enumNames
     }
 }
 
-public fun <T> ValidationBuilder<T>.const(expected: T): Constraint<T> = addConstraint("must be '$expected'") { expected == it }
+public fun <T> ValidationBuilder<T>.const(expected: T): Constraint<T> = constrain("must be '$expected'") { expected == it }

--- a/src/commonMain/kotlin/io/konform/validation/constraints/MapConstraints.kt
+++ b/src/commonMain/kotlin/io/konform/validation/constraints/MapConstraints.kt
@@ -4,22 +4,22 @@ import io.konform.validation.Constraint
 import io.konform.validation.ValidationBuilder
 
 public fun <T : Map<*, *>> ValidationBuilder<T>.minItems(minSize: Int): Constraint<T> =
-    addConstraint("must have at least {0} items", minSize.toString()) {
+    constrain("must have at least $minSize items") {
         it.count() >= minSize
     }
 
 public fun <T : Map<*, *>> ValidationBuilder<T>.maxItems(maxSize: Int): Constraint<T> =
-    addConstraint("must have at most {0} items", maxSize.toString()) {
+    constrain("must have at most $maxSize items") {
         it.count() <= maxSize
     }
 
 public fun <T : Map<*, *>> ValidationBuilder<T>.minProperties(minSize: Int): Constraint<T> =
-    minItems(minSize) hint "must have at least {0} properties"
+    minItems(minSize) hint "must have at least $minSize properties"
 
 public fun <T : Map<*, *>> ValidationBuilder<T>.maxProperties(maxSize: Int): Constraint<T> =
-    maxItems(maxSize) hint "must have at most {0} properties"
+    maxItems(maxSize) hint "must have at most $maxSize properties"
 
 public fun <T : Map<*, *>> ValidationBuilder<T>.uniqueItems(unique: Boolean = true): Constraint<T> =
-    addConstraint("all items must be unique") {
+    constrain("all items must be unique") {
         !unique || it.values.distinct().count() == it.count()
     }

--- a/src/commonMain/kotlin/io/konform/validation/constraints/NumberConstraints.kt
+++ b/src/commonMain/kotlin/io/konform/validation/constraints/NumberConstraints.kt
@@ -8,7 +8,7 @@ import kotlin.math.roundToInt
 public fun <T : Number> ValidationBuilder<T>.multipleOf(factor: Number): Constraint<T> {
     val factorAsDouble = factor.toDouble()
     require(factorAsDouble > 0) { "multipleOf requires the factor to be strictly larger than 0" }
-    return addConstraint("must be a multiple of '{0}'", factor.toString()) {
+    return constrain("must be a multiple of '$factor'") {
         val division = it.toDouble() / factorAsDouble
         division.compareTo(division.roundToInt()) == 0
     }

--- a/src/commonMain/kotlin/io/konform/validation/jsonschema/JsonSchema.kt
+++ b/src/commonMain/kotlin/io/konform/validation/jsonschema/JsonSchema.kt
@@ -78,40 +78,28 @@ public fun <T : Number> ValidationBuilder<T>.multipleOf(factor: Number): Constra
     ReplaceWith("maximum(maximumInclusive)", "io.konform.validation.constraints.maximum"),
 )
 public fun <T : Number> ValidationBuilder<T>.maximum(maximumInclusive: Number): Constraint<T> =
-    addConstraint(
-        "must be at most '{0}'",
-        maximumInclusive.toString(),
-    ) { it.toDouble() <= maximumInclusive.toDouble() }
+    constrain("must be at most '$maximumInclusive'") { it.toDouble() <= maximumInclusive.toDouble() }
 
 @Deprecated(
     "Moved to io.konform.validation.constraints",
     ReplaceWith("exclusiveMaximum(maximumExclusive)", "io.konform.validation.constraints.exclusiveMaximum"),
 )
 public fun <T : Number> ValidationBuilder<T>.exclusiveMaximum(maximumExclusive: Number): Constraint<T> =
-    addConstraint(
-        "must be less than '{0}'",
-        maximumExclusive.toString(),
-    ) { it.toDouble() < maximumExclusive.toDouble() }
+    constrain("must be less than '$maximumExclusive'") { it.toDouble() < maximumExclusive.toDouble() }
 
 @Deprecated(
     "Moved to io.konform.validation.constraints",
     ReplaceWith("minimum(minimumInclusive)", "io.konform.validation.constraints.minimum"),
 )
 public fun <T : Number> ValidationBuilder<T>.minimum(minimumInclusive: Number): Constraint<T> =
-    addConstraint(
-        "must be at least '{0}'",
-        minimumInclusive.toString(),
-    ) { it.toDouble() >= minimumInclusive.toDouble() }
+    constrain("must be at least '$minimumInclusive'") { it.toDouble() >= minimumInclusive.toDouble() }
 
 @Deprecated(
     "Moved to io.konform.validation.constraints",
     ReplaceWith("exclusiveMinimum(minimumExclusive)", "io.konform.validation.constraints.exclusiveMinimum"),
 )
 public fun <T : Number> ValidationBuilder<T>.exclusiveMinimum(minimumExclusive: Number): Constraint<T> =
-    addConstraint(
-        "must be greater than '{0}'",
-        minimumExclusive.toString(),
-    ) { it.toDouble() > minimumExclusive.toDouble() }
+    constrain("must be greater than '$minimumExclusive'") { it.toDouble() > minimumExclusive.toDouble() }
 
 @Suppress("UNCHECKED_CAST")
 @Deprecated(
@@ -119,10 +107,7 @@ public fun <T : Number> ValidationBuilder<T>.exclusiveMinimum(minimumExclusive: 
     ReplaceWith("minItems(minSize)", "io.konform.validation.constraints.minItems"),
 )
 public inline fun <reified T> ValidationBuilder<T>.minItems(minSize: Int): Constraint<T> =
-    addConstraint(
-        "must have at least {0} items",
-        minSize.toString(),
-    ) {
+    constrain("must have at least $minSize items") {
         when (it) {
             is Iterable<*> -> it.count() >= minSize
             is Array<*> -> it.count() >= minSize
@@ -136,10 +121,7 @@ public inline fun <reified T> ValidationBuilder<T>.minItems(minSize: Int): Const
     ReplaceWith("maxItems(maxSize)", "io.konform.validation.constraints.maxItems"),
 )
 public inline fun <reified T> ValidationBuilder<T>.maxItems(maxSize: Int): Constraint<T> =
-    addConstraint(
-        "must have at most {0} items",
-        maxSize.toString(),
-    ) {
+    constrain("must have at most $maxSize items") {
         when (it) {
             is Iterable<*> -> it.count() <= maxSize
             is Array<*> -> it.count() <= maxSize
@@ -153,23 +135,21 @@ public inline fun <reified T> ValidationBuilder<T>.maxItems(maxSize: Int): Const
     ReplaceWith("minProperties(maxSize)", "io.konform.validation.constraints.minProperties"),
 )
 public fun <K, V> ValidationBuilder<Map<K, V>>.minProperties(minSize: Int): Constraint<Map<K, V>> =
-    movedMinProperties(minSize) hint "must have at least {0} properties"
+    movedMinProperties(minSize) hint "must have at least $minSize properties"
 
 @Deprecated(
     "Moved to io.konform.validation.constraints",
     ReplaceWith("maxProperties(maxSize)", "io.konform.validation.constraints.maxProperties"),
 )
 public fun <K, V> ValidationBuilder<Map<K, V>>.maxProperties(maxSize: Int): Constraint<Map<K, V>> =
-    movedMaxProperties(maxSize) hint "must have at most {0} properties"
+    movedMaxProperties(maxSize) hint "must have at most $maxSize properties"
 
 @Deprecated(
     "Moved to io.konform.validation.constraints",
     ReplaceWith("uniqueItems(unique)", "io.konform.validation.constraints.uniqueItems"),
 )
 public inline fun <reified T> ValidationBuilder<T>.uniqueItems(unique: Boolean): Constraint<T> =
-    addConstraint(
-        "all items must be unique",
-    ) {
+    constrain("all items must be unique") {
         !unique ||
             when (it) {
                 is Iterable<*> -> it.distinct().count() == it.count()

--- a/src/commonTest/kotlin/io/konform/validation/ReadmeExampleTest.kt
+++ b/src/commonTest/kotlin/io/konform/validation/ReadmeExampleTest.kt
@@ -152,7 +152,7 @@ class ReadmeExampleTest {
         val validateUser1 =
             Validation<UserProfile> {
                 UserProfile::fullName {
-                    addConstraint("Name cannot contain a tab") { !it.contains("\t") }
+                    constrain("Name cannot contain a tab") { !it.contains("\t") }
                 }
             }
 


### PR DESCRIPTION
## Summary
- Replaced all internal usages of deprecated `addConstraint` with `constrain`
- Updated template value placeholders (`{0}`) to use string interpolation (`$variable`)
- Kept the `addConstraint` method itself for backward compatibility

## Changes
- `AnyConstraints.kt` - Updated `type()` constraint
- `EnumConstraints.kt` - Updated `enum()` and `const()` constraints  
- `MapConstraints.kt` - Updated `minItems()`, `maxItems()`, `minProperties()`, `maxProperties()`, and `uniqueItems()` constraints
- `NumberConstraints.kt` - Updated `multipleOf()` constraint
- `JsonSchema.kt` - Updated all deprecated wrapper functions
- `ReadmeExampleTest.kt` - Updated test example

## Testing
All existing tests pass, including comprehensive error message validation for every modified constraint. Error messages remain unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)